### PR TITLE
feature/extra styling properties

### DIFF
--- a/markdown2pdfrc.example.toml
+++ b/markdown2pdfrc.example.toml
@@ -8,6 +8,7 @@
 # - size: Font size in points
 # - textcolor: RGB text color values (0-255)
 # - backgroundcolor: RGB background color values (0-255)
+# - afterspacing: Vertical spacing before element in points
 # - afterspacing: Vertical spacing after element in points
 # - alignment: Text alignment (left|center|right|justify)
 # - fontfamily: Font family name
@@ -27,6 +28,7 @@ left = 8.0
 [heading.1]
 size = 14
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.8
 afterspacing = 0.5
 alignment = "center"
 fontfamily = "roboto"
@@ -40,6 +42,7 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [heading.2]
 size = 12
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.8
 afterspacing = 0.5
 alignment = "left"
 fontfamily = "roboto"
@@ -53,6 +56,7 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [heading.3]
 size = 10
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.8
 afterspacing = 0.5
 alignment = "left"
 fontfamily = "roboto"
@@ -66,6 +70,7 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [emphasis]
 size = 8
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.0
 afterspacing = 0.0
 alignment = "left"
 fontfamily = "roboto"
@@ -79,6 +84,7 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [strong_emphasis]
 size = 8
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.0
 afterspacing = 0.0
 alignment = "left"
 fontfamily = "roboto"
@@ -92,7 +98,8 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [code]
 size = 8
 textcolor = { r = 128, g = 128, b = 128 }
-afterspacing = 0.0
+beforespacing = 0.4
+afterspacing = 0.4
 alignment = "left"
 fontfamily = "roboto"
 bold = false
@@ -105,6 +112,7 @@ backgroundcolor = { r = 230, g = 230, b = 230 }
 [block_quote]
 size = 8
 textcolor = { r = 128, g = 128, b = 128 }
+beforespacing = 0.0
 afterspacing = 0.0
 alignment = "left"
 fontfamily = "roboto"
@@ -118,6 +126,7 @@ backgroundcolor = { r = 245, g = 245, b = 245 }
 [list_item]
 size = 8
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.0
 afterspacing = 0.5
 alignment = "left"
 fontfamily = "roboto"
@@ -157,6 +166,7 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [text]
 size = 8
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.0
 afterspacing = 0.0
 alignment = "left"
 fontfamily = "roboto"
@@ -170,6 +180,7 @@ backgroundcolor = { r = 255, g = 255, b = 255 }
 [horizontal_rule]
 size = 8
 textcolor = { r = 0, g = 0, b = 0 }
+beforespacing = 0.0
 afterspacing = 0.5
 alignment = "left"
 fontfamily = "roboto"

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -86,6 +86,11 @@ fn parse_style(value: Option<&Value>, default: BasicTextStyle) -> BasicTextStyle
         if let Some(size) = style_config.get("size").and_then(|v| v.as_integer()) {
             style.size = size as u8;
         }
+
+        if let Some(spacing) = style_config.get("beforespacing").and_then(|v| v.as_float()) {
+            style.before_spacing = spacing as f32;
+        }
+
         if let Some(spacing) = style_config.get("afterspacing").and_then(|v| v.as_float()) {
             style.after_spacing = spacing as f32;
         }

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -250,7 +250,7 @@ impl Lexer {
 
         Ok(Token::Emphasis {
             level: level.min(3), // Cap the level at 3
-            content: content,
+            content,
         })
     }
 

--- a/src/lib/pdf.rs
+++ b/src/lib/pdf.rs
@@ -185,6 +185,9 @@ impl Pdf {
             return;
         }
 
+        doc.push(genpdfi::elements::Break::new(
+            self.style.text.before_spacing,
+        ));
         let mut para = genpdfi::elements::Paragraph::default();
         self.render_inline_content(&mut para, tokens);
         doc.push(para);
@@ -198,12 +201,12 @@ impl Pdf {
     /// and text color based on the heading level configuration. After rendering the heading,
     /// it adds the configured spacing.
     fn render_heading(&self, doc: &mut Document, content: &[Token], level: usize) {
-        doc.push(genpdfi::elements::Break::new(0.8)); // TODO: make this configurable before_spacing
         let heading_style = match level {
             1 => &self.style.heading_1,
             2 => &self.style.heading_2,
             3 | _ => &self.style.heading_3,
         };
+        doc.push(genpdfi::elements::Break::new(heading_style.before_spacing));
 
         let mut para = genpdfi::elements::Paragraph::default();
         let mut style = genpdfi::style::Style::new().with_font_size(heading_style.size);
@@ -290,9 +293,11 @@ impl Pdf {
     /// paragraph with the configured code style. It applies the code font size and
     /// text color settings, and adds the configured spacing after the block.
     fn render_code_block(&self, doc: &mut Document, _lang: &str, content: &str) {
-        doc.push(genpdfi::elements::Break::new(0.4)); // TODO: make this configurable `before_spacing`
-        let mut style = genpdfi::style::Style::new().with_font_size(self.style.code.size);
+        doc.push(genpdfi::elements::Break::new(
+            self.style.code.before_spacing,
+        ));
 
+        let mut style = genpdfi::style::Style::new().with_font_size(self.style.code.size);
         if let Some(color) = self.style.code.text_color {
             style = style.with_color(genpdfi::style::Color::Rgb(color.0, color.1, color.2));
         }
@@ -329,6 +334,9 @@ impl Pdf {
         number: Option<usize>,
         nesting_level: usize,
     ) {
+        doc.push(genpdfi::elements::Break::new(
+            self.style.list_item.before_spacing,
+        ));
         let mut para = genpdfi::elements::Paragraph::default();
         let style = genpdfi::style::Style::new().with_font_size(self.style.list_item.size);
 

--- a/src/lib/styling.rs
+++ b/src/lib/styling.rs
@@ -121,6 +121,8 @@ pub struct BasicTextStyle {
     pub size: u8,
     /// Text color in RGB format
     pub text_color: Option<(u8, u8, u8)>,
+    /// Space before element in points
+    pub before_spacing: f32,
     /// Space after element in points
     pub after_spacing: f32,
     /// Text alignment within container
@@ -145,6 +147,7 @@ impl BasicTextStyle {
     /// # Arguments
     /// * `size` - Font size in points
     /// * `text_color` - Optional RGB color tuple for text
+    /// * `before_spacing` - Optional space before element in points
     /// * `after_spacing` - Optional space after element in points
     /// * `alignment` - Optional text alignment
     /// * `font_family` - Optional font family name
@@ -156,6 +159,7 @@ impl BasicTextStyle {
     pub fn new(
         size: u8,
         text_color: Option<(u8, u8, u8)>,
+        before_spacing: Option<f32>,
         after_spacing: Option<f32>,
         alignment: Option<TextAlignment>,
         font_family: Option<&'static str>,
@@ -168,6 +172,7 @@ impl BasicTextStyle {
         Self {
             size,
             text_color,
+            before_spacing: before_spacing.unwrap_or(0.0),
             after_spacing: after_spacing.unwrap_or(0.0),
             alignment,
             font_family,
@@ -210,6 +215,8 @@ pub struct StyleMatch {
     pub image: BasicTextStyle,
     /// Style for regular text
     pub text: BasicTextStyle,
+
+    // TODO: Not parsed into a actual horizontal rule currently, we need a proper styling for this
     /// Style for horizontal rules (---)
     pub horizontal_rule: BasicTextStyle,
 }
@@ -235,6 +242,7 @@ impl StyleMatch {
             heading_1: BasicTextStyle::new(
                 14,
                 Some((0, 0, 0)),
+                Some(0.8),
                 Some(0.5),
                 Some(TextAlignment::Center),
                 None,
@@ -247,6 +255,7 @@ impl StyleMatch {
             heading_2: BasicTextStyle::new(
                 12,
                 Some((0, 0, 0)),
+                Some(0.8),
                 Some(0.5),
                 Some(TextAlignment::Left),
                 None,
@@ -259,6 +268,7 @@ impl StyleMatch {
             heading_3: BasicTextStyle::new(
                 10,
                 Some((0, 0, 0)),
+                Some(0.8),
                 Some(0.5),
                 Some(TextAlignment::Left),
                 None,
@@ -274,6 +284,7 @@ impl StyleMatch {
                 None,
                 None,
                 None,
+                None,
                 false,
                 true,
                 false,
@@ -286,6 +297,7 @@ impl StyleMatch {
                 None,
                 None,
                 None,
+                None,
                 true,
                 false,
                 false,
@@ -295,6 +307,7 @@ impl StyleMatch {
             code: BasicTextStyle::new(
                 8,
                 Some((128, 128, 128)),
+                Some(0.4),
                 Some(0.4),
                 None,
                 Some("Roboto"),
@@ -310,6 +323,7 @@ impl StyleMatch {
                 None,
                 None,
                 None,
+                None,
                 false,
                 true,
                 false,
@@ -319,6 +333,7 @@ impl StyleMatch {
             list_item: BasicTextStyle::new(
                 8,
                 Some((0, 0, 0)),
+                None,
                 Some(0.5),
                 None,
                 None,
@@ -334,6 +349,7 @@ impl StyleMatch {
                 None,
                 None,
                 None,
+                None,
                 false,
                 false,
                 true,
@@ -343,6 +359,7 @@ impl StyleMatch {
             image: BasicTextStyle::new(
                 8,
                 Some((0, 0, 0)),
+                None,
                 None,
                 Some(TextAlignment::Center),
                 None,
@@ -358,6 +375,7 @@ impl StyleMatch {
                 None,
                 None,
                 None,
+                None,
                 false,
                 false,
                 false,
@@ -367,6 +385,7 @@ impl StyleMatch {
             horizontal_rule: BasicTextStyle::new(
                 8,
                 Some((0, 0, 0)),
+                None,
                 Some(0.5),
                 None,
                 None,


### PR DESCRIPTION
This pull request does not resolve any specific issue but addresses the `TODO`s related to configurable spacing before all PDF elements. For more details, please refer to the [markdown2pdfrc.example.toml](https://github.com/theiskaa/markdown2pdf/blob/main/markdown2pdfrc.example.toml) file in current branch.