### PR TITLE
chore: always embed the font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ assets/data
 .DS_Store
 
 *.pdf
+result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ genpdfi = "0.2.1"
 dirs = "4.0.0"
 toml = "0.8.19"
 once_cell = "1.20.2"
-rust-embed = "8.5.0"
+rust-embed = { version = "8.5.0", features = ["debug-embed"] }
 clap = { version = "4.0", features = ["derive"] }
 reqwest = { version = "0.12.9", features = ["blocking"], default-features = false }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750134718,
+        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750300711,
+        "narHash": "sha256-4XHPocwP+66PhxyyObPXfI+Rql4PoGe/xBK791N8I78=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4178888556c15e0a1c57850d2f103ac300a6e9e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,104 @@
+{
+  description = "markdown2pdf - Create PDF with Markdown files";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    crane,
+  }:
+    flake-utils.lib.eachDefaultSystem
+    (system: let
+      overlays = [(import rust-overlay)];
+      pkgs = import nixpkgs {
+        inherit system overlays;
+      };
+
+      craneLib = crane.mkLib pkgs;
+
+      rustSource = pkgs.lib.cleanSourceWith {
+        src = ./.;
+        filter = path: type:
+          craneLib.filterCargoSources path type
+          || pkgs.lib.hasInfix "/assets/" path;
+      };
+
+      # Function to build cargo artifacts for a specific profile
+      mkCargoArtifacts = profile:
+        craneLib.buildDepsOnly {
+          src = rustSource;
+          strictDeps = true;
+          pname = "markdown2pdf-deps-${profile}";
+          version = "0.1.3";
+          CARGO_PROFILE = profile;
+        };
+
+      # Function to build markdown2pdf for a specific profile
+      mkMarkdown2pdf = profile: let
+        cargoArtifacts = mkCargoArtifacts profile;
+      in
+        craneLib.buildPackage {
+          src = rustSource;
+          strictDeps = true;
+          inherit cargoArtifacts;
+          doCheck = false;
+          pname = "markdown2pdf";
+          version = "0.1.3";
+          CARGO_PROFILE = profile;
+        };
+
+      # Build artifacts and packages for both profiles
+      debugCargoArtifacts = mkCargoArtifacts "dev";
+      releaseCargoArtifacts = mkCargoArtifacts "release";
+
+      markdown2pdf-debug = mkMarkdown2pdf "dev";
+      markdown2pdf-release = mkMarkdown2pdf "release";
+
+      rustVersion = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      rustToolchain = rustVersion.override {
+        extensions = ["rust-analyzer" "rust-src"];
+      };
+
+      nativeBuildInputs = with pkgs; [
+        rustToolchain
+        cargo-nextest
+        cargo-audit
+        cargo-watch
+        cargo-deny
+        cargo-machete
+        bacon
+        typos
+      ];
+    in
+      with pkgs; {
+        packages = {
+          default = markdown2pdf-release;
+          debug = markdown2pdf-debug;
+          release = markdown2pdf-release;
+        };
+
+        apps.default = flake-utils.lib.mkApp {drv = markdown2pdf-release;};
+
+        devShells.default = mkShell {
+          inherit nativeBuildInputs;
+          shellHook = ''
+            echo "markdown2pdf development environment"
+          '';
+        };
+
+        formatter = alejandra;
+      });
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+profile = "default" 


### PR DESCRIPTION
because the fonts needs to be present at runtime in the folder, but only in debug, the behavior is quite inconsistent and different to understand unless someone dive into the code

when working with nix that have seggregated environement the issue is more acute, and it took me some time to understand why things where behaving differently between using cargo directly or using nix, and also why it changes between debug and release 

embedded the font also in debug would solve this issue probably

ie: `rust-embed = { version = "8.5.0", features = ["debug-embed"] }`

created the PR with all the code to reproduce the issue if that's useful context