### PR TITLE
fix(markdown): ignore `>` again in parse_text

### DIFF
--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -597,7 +597,7 @@ impl Lexer {
     fn is_start_of_special_token(&self, ctx: ParseContext) -> bool {
         let ch = self.current_char();
         match ch {
-            '#' | '>' if matches!(ctx, ParseContext::Root) => true,
+            '#' if matches!(ctx, ParseContext::Root) => true,
 
             // inline-compatible tokens
             '*' | '_' | '`' | '[' => true,


### PR DESCRIPTION
A bug was introduced with #51: when encountering `>` while parsing plain text, it would break with `UnknownToken("Unexpected character at position ...")`.  
This fix simply removes the useless check for `>`.