### PR TITLE
feature/html-parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,8 @@ env:
 
 jobs:
   test:
-    name: cargo test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: cargo test
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  # Lets you re-run the CI manually from the Actions tab.
+  workflow_dispatch:
+
+# Cancel in-progress runs of the same workflow on the same branch when
+# new commits are pushed — saves CI minutes during rapid iteration.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # The lexer + tests are warning-clean today; any new warning should
+  # block the merge until it's addressed.
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  test:
+    name: cargo test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --all-targets --verbose
+
+      - name: Test (lib unit + integration + spec + stress + doc)
+        run: cargo test --all-targets --verbose
+
+      - name: Doc tests
+        run: cargo test --doc --verbose
+
+      - name: CommonMark spec — surface full report in CI log
+        # Same suite as above, but re-runs the spec target with the
+        # per-section breakdown captured in the workflow log so any
+        # regression in spec compliance is visible without re-running
+        # CI locally.
+        run: cargo test --test commonmark_spec -- --nocapture

--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ For binary usage, create a config file at `~/markdown2pdfrc.toml` and copy the e
 
 ## Markdown Coverage
 
-Targets [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) + [GFM](https://github.github.com/gfm/). CommonMark spec pass rate: **92.9% (606/652)**. All 46 remaining failures are HTML-block / raw-HTML cases (intentionally out of scope) — every non-HTML section passes at 100%. Backed by ~680 inline unit tests organized in `src/lib/markdown_tests/`, the full spec runner in `tests/commonmark_spec.rs`, and a 36-test robustness suite in `tests/stress.rs`.
+Targets [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) + [GFM](https://github.github.com/gfm/). CommonMark spec pass rate: **100% (652/652)** — every section passes. Backed by ~740 inline unit tests organized in `tests/markdown/`, the full spec runner in `tests/commonmark_spec.rs`, and a 36-test robustness suite in `tests/stress.rs`.
 
 | Block-level                          | Status  | Inline                               | Status  |
 |--------------------------------------|---------|--------------------------------------|---------|
 | ATX headings (`#` to `######`)       | Full    | Backslash escapes                    | Full    |
-| Setext headings (`===` / `---`)      | Full    | Entity / numeric references          | Partial |
+| Setext headings (`===` / `---`)      | Full    | Entity / numeric references          | Full    |
 | Paragraphs                           | Full    | Code spans (single & multi-backtick) | Full    |
 | Thematic breaks (`---` `***` `___`)  | Full    | Emphasis & strong (`*` and `_`)      | Full    |
 | Indented code blocks (4-space)       | Full    | Inline links                         | Full    |
@@ -234,10 +234,10 @@ Targets [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) + [GFM](https:/
 | Blockquotes                          | Full    | Autolinks (`<https://…>`, `<email>`) | Full    |
 | Bullet lists (`-` `+` `*`)           | Full    | Images (rendered as styled link)     | Partial |
 | Ordered lists (`1.` and `1)`)        | Full    | Strikethrough (`~~text~~`)           | Full    |
-| Tables (GFM)                         | Full    | Raw inline HTML                      | Partial |
+| Tables (GFM)                         | Full    | Raw inline HTML                      | Full    |
 | Task list items (GFM)                | Full    | Hard / soft line breaks              | Full    |
 | Reference link definitions           | Full    |                                      |         |
-| HTML blocks (types 1–7)              | None    |                                      |         |
+| HTML blocks (7 kinds)                | Full    |                                      |         |
 
 ## Contributing
 For information regarding contributions, please refer to [CONTRIBUTING.md](CONTRIBUTING.md) file.

--- a/src/lib/debug.rs
+++ b/src/lib/debug.rs
@@ -344,6 +344,17 @@ impl Token {
                 )
             }
 
+            Token::HtmlBlock(html) => {
+                format!(
+                    "{}{{\n{}\"type\": \"HtmlBlock\",\n{}\"content\": \"{}\"\n{}}}",
+                    indent,
+                    inner_indent,
+                    inner_indent,
+                    html.replace("\"", "\\\""),
+                    indent
+                )
+            }
+
             Token::HardBreak => format!(
                 "{}{{\n{}\"type\": \"HardBreak\"\n{}}}",
                 indent, inner_indent, indent
@@ -511,6 +522,7 @@ impl Token {
             }
             Token::HtmlComment(content) => format!("HtmlComment({})", quote(content)),
             Token::HtmlInline(html) => format!("HtmlInline({})", quote(html)),
+            Token::HtmlBlock(html) => format!("HtmlBlock({})", quote(html)),
             Token::Newline => "Newline".to_string(),
             Token::HardBreak => "HardBreak".to_string(),
             Token::HorizontalRule => "HorizontalRule".to_string(),

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -4116,10 +4116,16 @@ impl Lexer {
 
     /// Checks if current position starts an HTML comment
     fn is_html_comment_start(&self) -> bool {
-        self.input[self.position..]
-            .iter()
-            .collect::<String>()
-            .starts_with("<!--")
+        // Per-character compare avoids the O(n) full-tail allocation
+        // that the old `iter().collect::<String>().starts_with("<!--")`
+        // shape produced. `parse_text` calls this once per character,
+        // so an O(n) probe here would turn the whole parse quadratic.
+        let p = self.position;
+        p + 3 < self.input.len()
+            && self.input[p] == '<'
+            && self.input[p + 1] == '!'
+            && self.input[p + 2] == '-'
+            && self.input[p + 3] == '-'
     }
 
     /// Checks if current position could start a special token given a context

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -3511,6 +3511,22 @@ impl Lexer {
             p
         };
 
+        // Type 2: `<!--…-->` block comments. Opener `<!--` at line start;
+        // body terminates at `-->` (multi-line allowed). Same `<!`
+        // prefix as Type 4 / Type 5 but disambiguated by the third char
+        // (`-` vs ASCII-letter vs `[`).
+        if self.position + 3 < self.input.len()
+            && self.input[self.position] == '<'
+            && self.input[self.position + 1] == '!'
+            && self.input[self.position + 2] == '-'
+            && self.input[self.position + 3] == '-'
+        {
+            let end = self.scan_html_block_to_terminator(self.position, "-->")?;
+            let content: String = self.input[block_start..end].iter().collect();
+            self.position = end;
+            return Some(Token::HtmlBlock(content));
+        }
+
         // Type 4: `<!LETTER…>` declarations (DOCTYPE, ELEMENT, etc.).
         // Body terminates at the first `>` on this or a subsequent
         // line. Opener pattern: `<!` followed by ASCII alphabetic char.

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -3525,6 +3525,27 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
+        // Type 5: `<![CDATA[…]]>` blocks.
+        // Body terminates at `]]>` (multi-line allowed). Opener pattern
+        // is the literal 9-char sequence `<![CDATA[`. Doesn't overlap
+        // with Type 4 because `<!` is followed by `[`, not a letter.
+        if self.position + 8 < self.input.len()
+            && self.input[self.position] == '<'
+            && self.input[self.position + 1] == '!'
+            && self.input[self.position + 2] == '['
+            && self.input[self.position + 3] == 'C'
+            && self.input[self.position + 4] == 'D'
+            && self.input[self.position + 5] == 'A'
+            && self.input[self.position + 6] == 'T'
+            && self.input[self.position + 7] == 'A'
+            && self.input[self.position + 8] == '['
+        {
+            let end = self.scan_html_block_to_terminator(self.position, "]]>")?;
+            let content: String = self.input[block_start..end].iter().collect();
+            self.position = end;
+            return Some(Token::HtmlBlock(content));
+        }
+
         None
     }
 

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -3623,6 +3623,32 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
+        // Block-element HTML blocks: opener is `<NAME` or `</NAME`
+        // where NAME (case-insensitive) is in BLOCK_ELEMENT_TAG_NAMES,
+        // followed by space, tab, end-of-line, `>`, or `/>`. The opener
+        // does NOT have to be syntactically complete — a line like
+        // `<div id="foo"` with no closing `>` is still a valid block
+        // start. Body runs to the next blank line or EOF; content is
+        // verbatim. This kind CAN interrupt an open paragraph (no
+        // previous_line_is_blank_or_bof check).
+        if self.input[self.position] == '<'
+            && self.is_block_element_opener_at(self.position)
+        {
+            let mut after_opener_line = self.position;
+            while after_opener_line < self.input.len()
+                && self.input[after_opener_line] != '\n'
+            {
+                after_opener_line += 1;
+            }
+            if after_opener_line < self.input.len() {
+                after_opener_line += 1;
+            }
+            let end = self.scan_to_blank_line(after_opener_line);
+            let content: String = self.input[block_start..end].iter().collect();
+            self.position = end;
+            return Some(Token::HtmlBlock(content));
+        }
+
         // Standalone HTML tag blocks: any complete open or close tag,
         // followed by ONLY spaces or tabs to the end of the line, whose
         // tag name is not in the raw-content list (handled above) and
@@ -3770,6 +3796,44 @@ impl Lexer {
         }
         let name: String = self.input[name_start..p].iter().collect();
         Some(name.to_ascii_lowercase())
+    }
+
+    /// Returns true if `chars[pos..]` matches the opener of a
+    /// block-element HTML block — `<NAME` or `</NAME` where NAME (case-
+    /// insensitive) is in BLOCK_ELEMENT_TAG_NAMES, followed by space,
+    /// tab, end-of-line, `>`, or `/>`. The opener does NOT need to be
+    /// syntactically complete; this check stops right after the tag
+    /// name and validates the trailing delimiter.
+    fn is_block_element_opener_at(&self, pos: usize) -> bool {
+        if pos >= self.input.len() || self.input[pos] != '<' {
+            return false;
+        }
+        let mut p = pos + 1;
+        if p < self.input.len() && self.input[p] == '/' {
+            p += 1;
+        }
+        if p >= self.input.len() || !self.input[p].is_ascii_alphabetic() {
+            return false;
+        }
+        let name_start = p;
+        while p < self.input.len()
+            && (self.input[p].is_ascii_alphanumeric() || self.input[p] == '-')
+        {
+            p += 1;
+        }
+        let name: String = self.input[name_start..p].iter().collect();
+        let name_lower = name.to_ascii_lowercase();
+        if !BLOCK_ELEMENT_TAG_NAMES
+            .iter()
+            .any(|t| *t == name_lower.as_str())
+        {
+            return false;
+        }
+        match self.input.get(p).copied() {
+            None | Some(' ') | Some('\t') | Some('\n') | Some('>') => true,
+            Some('/') => self.input.get(p + 1).copied() == Some('>'),
+            _ => false,
+        }
     }
 
     /// True if every character from `pos` until the next `\n` (or EOF)

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -3546,6 +3546,19 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
+        // Type 3: `<?…?>` processing instructions (e.g. PHP, XML PIs).
+        // Body terminates at `?>` (multi-line allowed). Opener is the
+        // 2-char sequence `<?`.
+        if self.position + 1 < self.input.len()
+            && self.input[self.position] == '<'
+            && self.input[self.position + 1] == '?'
+        {
+            let end = self.scan_html_block_to_terminator(self.position, "?>")?;
+            let content: String = self.input[block_start..end].iter().collect();
+            self.position = end;
+            return Some(Token::HtmlBlock(content));
+        }
+
         None
     }
 

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -3480,20 +3480,27 @@ impl Lexer {
     /// Caller is responsible for verifying line-start and 0-3-space
     /// indent before calling.
     ///
-    /// This is the dispatcher across the seven CommonMark HTML block
-    /// types. Each type is recognized by its OPENER, then its body runs
-    /// per the type-specific termination rule:
-    ///   Type 1: until matching `</script|pre|style|textarea>` (any line)
-    ///   Type 2: until `-->`
-    ///   Type 3: until `?>`
-    ///   Type 4: until `>`
-    ///   Type 5: until `]]>`
-    ///   Type 6: until blank line or EOF
-    ///   Type 7: until blank line or EOF
+    /// Recognizes any of the seven CommonMark HTML block kinds by
+    /// matching its opener, then consuming the body per kind-specific
+    /// termination rules:
     ///
-    /// Types are checked in spec order — that's required because Type 4
-    /// would otherwise mis-claim Type 2 / Type 5 openers (`<!--` and
-    /// `<![CDATA[` both start with `<!`).
+    ///   Raw-content blocks (`<script|pre|style|textarea …>`):
+    ///       until a line containing `</script>` / `</pre>` /
+    ///       `</style>` / `</textarea>` (case-insensitive) appears.
+    ///   HTML block comments (`<!--…-->`): until `-->`.
+    ///   Processing instructions (`<?…?>`): until `?>`.
+    ///   Declarations (`<!LETTER…>`, e.g. DOCTYPE): until `>`.
+    ///   CDATA sections (`<![CDATA[…]]>`): until `]]>`.
+    ///   Block-element tags (whitelisted: `<div>`, `<table>`, …):
+    ///       until blank line or EOF (NOT YET IMPLEMENTED).
+    ///   Standalone tags (any complete tag on its own line):
+    ///       until blank line or EOF (NOT YET IMPLEMENTED).
+    ///
+    /// Openers that share the `<!` prefix (comments, declarations,
+    /// CDATA) are distinguished by the third character (`-`, ASCII
+    /// letter, or `[`); the checks below sit in this dispatch order
+    /// to mirror spec ordering even where patterns are technically
+    /// disjoint.
     fn try_parse_html_block(&mut self) -> Option<Token> {
         // We're called from `next_token` at the current `<`. The caller
         // has already verified `is_block_marker_start()` (line start +
@@ -3511,10 +3518,27 @@ impl Lexer {
             p
         };
 
-        // Type 2: `<!--…-->` block comments. Opener `<!--` at line start;
-        // body terminates at `-->` (multi-line allowed). Same `<!`
-        // prefix as Type 4 / Type 5 but disambiguated by the third char
-        // (`-` vs ASCII-letter vs `[`).
+        // Raw-content blocks (`<script>`, `<pre>`, `<style>`,
+        // `<textarea>`). Opener is the tag name (case-insensitive)
+        // followed by space, tab, `>`, or end-of-line. Body terminates
+        // at a line that *contains* any of `</script>` / `</pre>` /
+        // `</style>` / `</textarea>` (case-insensitive — per spec the
+        // closer "need not match the start tag"). If no closer ever
+        // appears, the block runs to EOF. Body is verbatim — no
+        // markdown parsing happens inside.
+        if self.input[self.position] == '<'
+            && self.is_raw_html_block_opener_at(self.position + 1)
+        {
+            let end = self.scan_to_raw_html_block_close(self.position);
+            let content: String = self.input[block_start..end].iter().collect();
+            self.position = end;
+            return Some(Token::HtmlBlock(content));
+        }
+
+        // HTML block comments: opener `<!--` at line start; body
+        // terminates at `-->` (multi-line allowed). Distinct from the
+        // declaration / CDATA arms below by the third char (`-` vs
+        // ASCII-letter vs `[`).
         if self.position + 3 < self.input.len()
             && self.input[self.position] == '<'
             && self.input[self.position + 1] == '!'
@@ -3527,9 +3551,9 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
-        // Type 4: `<!LETTER…>` declarations (DOCTYPE, ELEMENT, etc.).
-        // Body terminates at the first `>` on this or a subsequent
-        // line. Opener pattern: `<!` followed by ASCII alphabetic char.
+        // Declarations (`<!DOCTYPE`, `<!ELEMENT`, `<!ATTLIST`, …):
+        // body terminates at the first `>` on this or a subsequent
+        // line. Opener pattern is `<!` followed by an ASCII letter.
         if self.position + 2 < self.input.len()
             && self.input[self.position] == '<'
             && self.input[self.position + 1] == '!'
@@ -3541,10 +3565,10 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
-        // Type 5: `<![CDATA[…]]>` blocks.
-        // Body terminates at `]]>` (multi-line allowed). Opener pattern
-        // is the literal 9-char sequence `<![CDATA[`. Doesn't overlap
-        // with Type 4 because `<!` is followed by `[`, not a letter.
+        // CDATA sections (`<![CDATA[…]]>`): body terminates at `]]>`
+        // (multi-line allowed). Opener is the literal 9-char sequence
+        // `<![CDATA[`. Doesn't overlap with the declaration arm because
+        // `<!` is followed by `[`, not a letter.
         if self.position + 8 < self.input.len()
             && self.input[self.position] == '<'
             && self.input[self.position + 1] == '!'
@@ -3562,8 +3586,8 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
-        // Type 3: `<?…?>` processing instructions (e.g. PHP, XML PIs).
-        // Body terminates at `?>` (multi-line allowed). Opener is the
+        // Processing instructions (`<?…?>`, e.g. PHP, XML PIs):
+        // body terminates at `?>` (multi-line allowed). Opener is the
         // 2-char sequence `<?`.
         if self.position + 1 < self.input.len()
             && self.input[self.position] == '<'
@@ -3578,10 +3602,10 @@ impl Lexer {
         None
     }
 
-    /// Scans forward from `start` looking for `terminator` (e.g. `>` for
-    /// Type 4 decl, `?>` for Type 3 PI, `]]>` for Type 5 CDATA, `-->`
-    /// for Type 2 comment) and returns the byte index AFTER the
-    /// terminator + the trailing newline (if any) — so the caller can
+    /// Scans forward from `start` looking for `terminator` (e.g. `>`
+    /// for a declaration, `?>` for a processing instruction, `]]>` for
+    /// CDATA, `-->` for a block comment) and returns the byte index
+    /// AFTER the terminator + the trailing newline (if any) — caller can
     /// slice `[block_start..returned]` as the verbatim block content
     /// and set `self.position = returned` to move past the block.
     ///
@@ -3610,6 +3634,72 @@ impl Lexer {
             p += 1;
         }
         None
+    }
+
+    /// Returns true if `chars[pos..]` starts with one of the four
+    /// raw-content HTML block tag names (`script`, `pre`, `style`,
+    /// `textarea`, case-insensitive) followed by a valid opener
+    /// delimiter (space, tab, `>`, or end-of-line). Used by
+    /// `try_parse_html_block` after the initial `<` is consumed
+    /// (caller passes `self.position + 1`).
+    fn is_raw_html_block_opener_at(&self, pos: usize) -> bool {
+        const TAGS: &[&str] = &["script", "pre", "style", "textarea"];
+        for &tag in TAGS {
+            let len = tag.chars().count();
+            if pos + len > self.input.len() {
+                continue;
+            }
+            // Case-insensitive ASCII match on the tag name.
+            let ok = self.input[pos..pos + len]
+                .iter()
+                .zip(tag.chars())
+                .all(|(a, b)| a.eq_ignore_ascii_case(&b));
+            if !ok {
+                continue;
+            }
+            // Validate the char after the tag name.
+            match self.input.get(pos + len).copied() {
+                None | Some(' ') | Some('\t') | Some('\n') | Some('>') => return true,
+                _ => continue,
+            }
+        }
+        false
+    }
+
+    /// Scans line-by-line from `start` looking for any of the four
+    /// raw-content closing tags (`</script>`, `</pre>`, `</style>`,
+    /// `</textarea>`, case-insensitive) anywhere on a line. Returns the
+    /// position just past the newline of the closing line, or
+    /// `self.input.len()` if no closer is found — in that case the
+    /// block runs to EOF, which the CommonMark spec explicitly allows.
+    fn scan_to_raw_html_block_close(&self, start: usize) -> usize {
+        const CLOSERS: &[&str] = &["</script>", "</pre>", "</style>", "</textarea>"];
+        let mut line_start = start;
+        while line_start < self.input.len() {
+            let mut line_end = line_start;
+            while line_end < self.input.len() && self.input[line_end] != '\n' {
+                line_end += 1;
+            }
+            let line_lower: String = self.input[line_start..line_end]
+                .iter()
+                .flat_map(|c| c.to_lowercase())
+                .collect();
+            for &closer in CLOSERS {
+                if line_lower.contains(closer) {
+                    return if line_end < self.input.len() {
+                        line_end + 1
+                    } else {
+                        line_end
+                    };
+                }
+            }
+            line_start = if line_end < self.input.len() {
+                line_end + 1
+            } else {
+                line_end
+            };
+        }
+        self.input.len()
     }
 
     /// Checks if current position is at the start of a line

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -142,6 +142,11 @@ pub enum Token {
     /// Raw inline HTML (`<span>`, `</span>`, `<br/>`, etc.)
     /// Stored verbatim including the angle brackets.
     HtmlInline(String),
+    /// Block-level raw HTML (CommonMark §4.6). Content is the verbatim
+    /// block text including all original whitespace and line endings.
+    /// Renderers should pass it through unmodified or skip it — no
+    /// markdown parsing happens inside.
+    HtmlBlock(String),
     /// Soft line break (single `\n`).
     Newline,
     /// Hard line break: two-or-more trailing spaces or a
@@ -229,6 +234,7 @@ impl Token {
             }
             Token::HtmlComment(comment) => result.push_str(comment),
             Token::HtmlInline(html) => result.push_str(html),
+            Token::HtmlBlock(html) => result.push_str(html),
             Token::Unknown(text) => result.push_str(text),
             Token::Newline | Token::HardBreak | Token::HorizontalRule => {
                 // These don't contain text
@@ -1792,6 +1798,26 @@ impl Lexer {
                 // Check if this is a valid image start (! followed by [)
                 if self.position + 1 < self.input.len() && self.input[self.position + 1] == '[' {
                     self.parse_image()?
+                } else {
+                    self.parse_text(ctx)?
+                }
+            }
+            '<' if is_block_start && allow_block_tokens(ctx) => {
+                // HTML block detection runs first at line start; falls
+                // through to inline-comment / autolink / inline-tag /
+                // text if no block construct fits.
+                if let Some(block) = self.try_parse_html_block() {
+                    block
+                } else if self.is_html_comment_start() {
+                    self.parse_html_comment()?
+                } else if let Some(autolink) = self.try_parse_autolink() {
+                    autolink
+                } else if let Some(len) = self.try_match_html_tag_len() {
+                    let html: String = self.input[self.position..self.position + len]
+                        .iter()
+                        .collect();
+                    self.position += len;
+                    Token::HtmlInline(html)
                 } else {
                     self.parse_text(ctx)?
                 }
@@ -3442,6 +3468,98 @@ impl Lexer {
             self.position = self.input.len();
             Ok(Token::Text(raw))
         }
+    }
+
+    /// Tries to consume an HTML block (CommonMark §4.6) starting at the
+    /// current position. Returns `Some(Token::HtmlBlock(content))` on a
+    /// successful match — content is the verbatim block text including
+    /// the opening line and any trailing newline — or `None` if no HTML
+    /// block fits, in which case the caller can fall through to inline
+    /// HTML handling (comment / autolink / inline tag / text).
+    ///
+    /// Caller is responsible for verifying line-start and 0-3-space
+    /// indent before calling.
+    ///
+    /// This is the dispatcher across the seven CommonMark HTML block
+    /// types. Each type is recognized by its OPENER, then its body runs
+    /// per the type-specific termination rule:
+    ///   Type 1: until matching `</script|pre|style|textarea>` (any line)
+    ///   Type 2: until `-->`
+    ///   Type 3: until `?>`
+    ///   Type 4: until `>`
+    ///   Type 5: until `]]>`
+    ///   Type 6: until blank line or EOF
+    ///   Type 7: until blank line or EOF
+    ///
+    /// Types are checked in spec order — that's required because Type 4
+    /// would otherwise mis-claim Type 2 / Type 5 openers (`<!--` and
+    /// `<![CDATA[` both start with `<!`).
+    fn try_parse_html_block(&mut self) -> Option<Token> {
+        // We're called from `next_token` at the current `<`. The caller
+        // has already verified `is_block_marker_start()` (line start +
+        // 0-3 space indent), but `self.position` itself sits at the `<`
+        // because `skip_whitespace` ran first. We need to capture the
+        // ORIGINAL line start (including the up-to-3 spaces of indent)
+        // so the block body preserves that indent verbatim per spec
+        // (example 184: `  <div>\n…` keeps the 2-space indent in the
+        // emitted HtmlBlock content).
+        let block_start = {
+            let mut p = self.position;
+            while p > 0 && self.input[p - 1] == ' ' {
+                p -= 1;
+            }
+            p
+        };
+
+        // Type 4: `<!LETTER…>` declarations (DOCTYPE, ELEMENT, etc.).
+        // Body terminates at the first `>` on this or a subsequent
+        // line. Opener pattern: `<!` followed by ASCII alphabetic char.
+        if self.position + 2 < self.input.len()
+            && self.input[self.position] == '<'
+            && self.input[self.position + 1] == '!'
+            && self.input[self.position + 2].is_ascii_alphabetic()
+        {
+            let end = self.scan_html_block_to_terminator(self.position, ">")?;
+            let content: String = self.input[block_start..end].iter().collect();
+            self.position = end;
+            return Some(Token::HtmlBlock(content));
+        }
+
+        None
+    }
+
+    /// Scans forward from `start` looking for `terminator` (e.g. `>` for
+    /// Type 4 decl, `?>` for Type 3 PI, `]]>` for Type 5 CDATA, `-->`
+    /// for Type 2 comment) and returns the byte index AFTER the
+    /// terminator + the trailing newline (if any) — so the caller can
+    /// slice `[block_start..returned]` as the verbatim block content
+    /// and set `self.position = returned` to move past the block.
+    ///
+    /// Returns `None` if the terminator is never reached before EOF —
+    /// the caller falls through to inline HTML handling so an
+    /// unterminated declaration / PI / CDATA / comment doesn't consume
+    /// the rest of the document as a block.
+    fn scan_html_block_to_terminator(&self, start: usize, terminator: &str) -> Option<usize> {
+        let term: Vec<char> = terminator.chars().collect();
+        let mut p = start;
+        while p + term.len() <= self.input.len() {
+            if self.input[p..p + term.len()] == term[..] {
+                let after = p + term.len();
+                // Consume the rest of the line (terminator may be
+                // followed by whitespace + newline, all of which is
+                // part of the block per spec).
+                let mut tail = after;
+                while tail < self.input.len() && self.input[tail] != '\n' {
+                    tail += 1;
+                }
+                if tail < self.input.len() {
+                    tail += 1; // include the `\n`
+                }
+                return Some(tail);
+            }
+            p += 1;
+        }
+        None
     }
 
     /// Checks if current position is at the start of a line

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -1842,6 +1842,12 @@ impl Lexer {
                         .collect();
                     self.position += len;
                     Token::HtmlInline(html)
+                } else if let Some(len) = self.try_match_inline_raw_html_special() {
+                    let html: String = self.input[self.position..self.position + len]
+                        .iter()
+                        .collect();
+                    self.position += len;
+                    Token::HtmlInline(html)
                 } else {
                     self.parse_text(ctx)?
                 }
@@ -1851,6 +1857,12 @@ impl Lexer {
                 if let Some(autolink) = self.try_parse_autolink() {
                     autolink
                 } else if let Some(len) = self.try_match_html_tag_len() {
+                    let html: String = self.input[self.position..self.position + len]
+                        .iter()
+                        .collect();
+                    self.position += len;
+                    Token::HtmlInline(html)
+                } else if let Some(len) = self.try_match_inline_raw_html_special() {
                     let html: String = self.input[self.position..self.position + len]
                         .iter()
                         .collect();
@@ -3181,14 +3193,17 @@ impl Lexer {
                         p += 1;
                     }
                     _ => {
-                        // Unquoted value: chars until whitespace/`>`.
+                        // Unquoted attribute value per CommonMark §6.6:
+                        // a nonempty string of characters excluding
+                        // whitespace, `"`, `'`, `=`, `<`, `>`, `` ` ``.
+                        // Note `/` IS allowed (e.g. `href=/path`); the
+                        // outer attribute loop separately handles `/>`.
                         if "\"'=<>`".contains(chars[p]) {
                             return None;
                         }
                         while p < chars.len()
                             && !chars[p].is_whitespace()
-                            && chars[p] != '>'
-                            && chars[p] != '/'
+                            && !"\"'=<>`".contains(chars[p])
                         {
                             p += 1;
                         }
@@ -3199,6 +3214,77 @@ impl Lexer {
                 p = attr_end;
             }
         }
+    }
+
+    /// Recognizes inline raw HTML that isn't an open / close tag —
+    /// processing instructions (`<?…?>`), declarations (`<!LETTER…>`),
+    /// and CDATA sections (`<![CDATA[…]]>`). Returns the matched
+    /// length on success or `None` if the current position doesn't
+    /// open one of these constructs (or the terminator never appears).
+    ///
+    /// Block-level forms are handled by `try_parse_html_block`; this
+    /// method covers the inline (mid-paragraph) case.
+    fn try_match_inline_raw_html_special(&self) -> Option<usize> {
+        if self.current_char() != '<' {
+            return None;
+        }
+        let pos = self.position;
+        let chars = &self.input;
+        if pos + 1 >= chars.len() {
+            return None;
+        }
+
+        // Processing instruction: `<?…?>`.
+        if chars[pos + 1] == '?' {
+            let mut p = pos + 2;
+            while p + 1 < chars.len() {
+                if chars[p] == '?' && chars[p + 1] == '>' {
+                    return Some(p + 2 - pos);
+                }
+                p += 1;
+            }
+            return None;
+        }
+
+        // CDATA section: `<![CDATA[…]]>`.
+        if pos + 8 < chars.len()
+            && chars[pos + 1] == '!'
+            && chars[pos + 2] == '['
+            && chars[pos + 3] == 'C'
+            && chars[pos + 4] == 'D'
+            && chars[pos + 5] == 'A'
+            && chars[pos + 6] == 'T'
+            && chars[pos + 7] == 'A'
+            && chars[pos + 8] == '['
+        {
+            let mut p = pos + 9;
+            while p + 2 < chars.len() {
+                if chars[p] == ']' && chars[p + 1] == ']' && chars[p + 2] == '>' {
+                    return Some(p + 3 - pos);
+                }
+                p += 1;
+            }
+            return None;
+        }
+
+        // Declaration: `<!LETTER…>`. Distinguished from CDATA by the
+        // third character (`[` vs ASCII letter) and from comments by
+        // the third character (`-` for comments, letter here).
+        if pos + 2 < chars.len()
+            && chars[pos + 1] == '!'
+            && chars[pos + 2].is_ascii_alphabetic()
+        {
+            let mut p = pos + 3;
+            while p < chars.len() {
+                if chars[p] == '>' {
+                    return Some(p + 1 - pos);
+                }
+                p += 1;
+            }
+            return None;
+        }
+
+        None
     }
 
     /// Cheap predicate used by `is_start_of_special_token`: scans the chars
@@ -3471,8 +3557,25 @@ impl Lexer {
         // that happens to contain a partial comment.
         let opener = self.position;
         self.position += 4; // Skip past '<', '!', '-', '-'
-        let start = self.position;
 
+        // Short-form comments per CommonMark §6.6:
+        //   <!-->   — empty body
+        //   <!--->  — body is a single hyphen
+        // Both must close immediately at this position; otherwise we
+        // fall through to the regular `-->` scan below.
+        if self.position < self.input.len() && self.input[self.position] == '>' {
+            self.position += 1;
+            return Ok(Token::HtmlComment(String::new()));
+        }
+        if self.position + 1 < self.input.len()
+            && self.input[self.position] == '-'
+            && self.input[self.position + 1] == '>'
+        {
+            self.position += 2;
+            return Ok(Token::HtmlComment("-".to_string()));
+        }
+
+        let start = self.position;
         while self.position + 2 < self.input.len() {
             if self.input[self.position] == '-'
                 && self.input[self.position + 1] == '-'
@@ -4061,7 +4164,13 @@ impl Lexer {
                     return true;
                 }
                 // Raw HTML tags (`<span>`, `</span>`, `<br/>`).
-                self.try_match_html_tag_len().is_some()
+                if self.try_match_html_tag_len().is_some() {
+                    return true;
+                }
+                // Inline raw-HTML specials: processing instructions
+                // `<?…?>`, declarations `<!LETTER…>`, CDATA sections
+                // `<![CDATA[…]]>`.
+                self.try_match_inline_raw_html_special().is_some()
             }
 
             _ => false,

--- a/src/lib/markdown.rs
+++ b/src/lib/markdown.rs
@@ -47,6 +47,30 @@ use genpdfi::Alignment;
 use std::collections::HashMap;
 
 include!(concat!(env!("OUT_DIR"), "/entities_table.rs"));
+
+/// Tag names that open a raw-content HTML block (CommonMark §4.6).
+/// Body runs verbatim until a matching closer appears on any line.
+const RAW_HTML_BLOCK_TAG_NAMES: &[&str] = &["script", "pre", "style", "textarea"];
+
+/// Tag names that open a block-element HTML block (CommonMark §4.6).
+/// Used for two purposes today:
+///   1. To EXCLUDE these names from the standalone-tag arm (so a
+///      `<div>` line doesn't get claimed by the wrong arm).
+///   2. As the basis for the dedicated block-element arm that will
+///      land in a follow-up commit (with its own opener-completeness
+///      and paragraph-interrupt rules).
+const BLOCK_ELEMENT_TAG_NAMES: &[&str] = &[
+    "address", "article", "aside", "base", "basefont", "blockquote",
+    "body", "caption", "center", "col", "colgroup", "dd", "details",
+    "dialog", "dir", "div", "dl", "dt", "fieldset", "figcaption",
+    "figure", "footer", "form", "frame", "frameset", "h1", "h2", "h3",
+    "h4", "h5", "h6", "head", "header", "hr", "html", "iframe",
+    "legend", "li", "link", "main", "menu", "menuitem", "nav",
+    "noframes", "ol", "optgroup", "option", "p", "param", "search",
+    "section", "summary", "table", "tbody", "td", "tfoot", "th",
+    "thead", "title", "tr", "track", "ul",
+];
+
 /// Parsing context — determines which tokens are valid in the current location.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParseContext {
@@ -3599,6 +3623,63 @@ impl Lexer {
             return Some(Token::HtmlBlock(content));
         }
 
+        // Standalone HTML tag blocks: any complete open or close tag,
+        // followed by ONLY spaces or tabs to the end of the line, whose
+        // tag name is not in the raw-content list (handled above) and
+        // not in the block-element whitelist (handled by the
+        // not-yet-implemented block-element arm — once that lands,
+        // these two arms split cleanly). Body runs until a blank line
+        // or EOF; content is verbatim.
+        //
+        // Precedence rule: this kind CANNOT interrupt an open paragraph
+        // (per CommonMark spec). When the previous line is non-blank,
+        // we fall through so the line stays part of the paragraph.
+        if self.input[self.position] == '<' && self.previous_line_is_blank_or_bof() {
+            if let Some(tag_name) = self.extract_html_tag_name_at(self.position) {
+                let name_lower = tag_name.to_ascii_lowercase();
+                let is_block_element = BLOCK_ELEMENT_TAG_NAMES
+                    .iter()
+                    .any(|t| t.eq_ignore_ascii_case(&name_lower));
+                let is_raw_content = RAW_HTML_BLOCK_TAG_NAMES
+                    .iter()
+                    .any(|t| t.eq_ignore_ascii_case(&name_lower));
+                if !is_block_element && !is_raw_content {
+                    if let Some(tag_len) = self.try_match_html_tag_len() {
+                        let after_tag = self.position + tag_len;
+                        // The complete tag must fit on a single line.
+                        // CommonMark's Type 7 start condition is "line
+                        // begins with a complete open tag ... followed
+                        // by ... the end of the line" — a tag whose
+                        // attributes wrap onto a continuation line
+                        // (e.g. `<a href="foo\nbar">`) doesn't qualify
+                        // and stays as inline HTML inside a paragraph.
+                        let tag_spans_newline = self.input[self.position..after_tag]
+                            .iter()
+                            .any(|c| *c == '\n');
+                        if !tag_spans_newline
+                            && self.is_only_whitespace_to_eol(after_tag)
+                        {
+                            // Move past the opener line's `\n` so the
+                            // blank-line scan starts on the next line.
+                            let mut after_opener_line = after_tag;
+                            while after_opener_line < self.input.len()
+                                && self.input[after_opener_line] != '\n'
+                            {
+                                after_opener_line += 1;
+                            }
+                            if after_opener_line < self.input.len() {
+                                after_opener_line += 1;
+                            }
+                            let end = self.scan_to_blank_line(after_opener_line);
+                            let content: String = self.input[block_start..end].iter().collect();
+                            self.position = end;
+                            return Some(Token::HtmlBlock(content));
+                        }
+                    }
+                }
+            }
+        }
+
         None
     }
 
@@ -3664,6 +3745,75 @@ impl Lexer {
             }
         }
         false
+    }
+
+    /// Returns the (lowercase) tag name at `pos` if the position sits
+    /// at the start of a complete or partial HTML tag. Handles both
+    /// open tags `<name>` and close tags `</name>`. Returns `None` if
+    /// the position is not at a recognizable tag opener.
+    fn extract_html_tag_name_at(&self, pos: usize) -> Option<String> {
+        if pos >= self.input.len() || self.input[pos] != '<' {
+            return None;
+        }
+        let mut p = pos + 1;
+        if p < self.input.len() && self.input[p] == '/' {
+            p += 1;
+        }
+        if p >= self.input.len() || !self.input[p].is_ascii_alphabetic() {
+            return None;
+        }
+        let name_start = p;
+        while p < self.input.len()
+            && (self.input[p].is_ascii_alphanumeric() || self.input[p] == '-')
+        {
+            p += 1;
+        }
+        let name: String = self.input[name_start..p].iter().collect();
+        Some(name.to_ascii_lowercase())
+    }
+
+    /// True if every character from `pos` until the next `\n` (or EOF)
+    /// is a space or tab. Used by the standalone-tag arm to enforce
+    /// the "complete tag followed by ONLY whitespace to end-of-line"
+    /// rule.
+    fn is_only_whitespace_to_eol(&self, pos: usize) -> bool {
+        let mut p = pos;
+        while p < self.input.len() && self.input[p] != '\n' {
+            if self.input[p] != ' ' && self.input[p] != '\t' {
+                return false;
+            }
+            p += 1;
+        }
+        true
+    }
+
+    /// Scans from `start` (must be at line-start) line by line until a
+    /// blank line (only whitespace + newline, or empty line). Returns
+    /// the position at the start of that blank line — the blank line
+    /// itself is NOT included in the result. If no blank line ever
+    /// appears, returns `self.input.len()` so the caller treats the
+    /// rest of the document as block content.
+    fn scan_to_blank_line(&self, start: usize) -> usize {
+        let mut p = start;
+        while p < self.input.len() {
+            let line_start = p;
+            let mut line_end = line_start;
+            while line_end < self.input.len() && self.input[line_end] != '\n' {
+                line_end += 1;
+            }
+            let is_blank = self.input[line_start..line_end]
+                .iter()
+                .all(|c| *c == ' ' || *c == '\t');
+            if is_blank {
+                return line_start;
+            }
+            p = if line_end < self.input.len() {
+                line_end + 1
+            } else {
+                line_end
+            };
+        }
+        self.input.len()
     }
 
     /// Scans line-by-line from `start` looking for any of the four

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -56,8 +56,11 @@ mod gfm_trio_tests;
 #[path = "markdown/hard_break_extended_tests.rs"]
 mod hard_break_extended_tests;
 
-#[path = "markdown/html_block_type_4_declaration_tests.rs"]
-mod html_block_type_4_declaration_tests;
+#[path = "markdown/html_declaration_tests.rs"]
+mod html_declaration_tests;
+
+#[path = "markdown/html_cdata_tests.rs"]
+mod html_cdata_tests;
 
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -77,6 +77,9 @@ mod html_standalone_tag_block_tests;
 #[path = "markdown/html_block_element_tests.rs"]
 mod html_block_element_tests;
 
+#[path = "markdown/html_inline_edge_tests.rs"]
+mod html_inline_edge_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -62,6 +62,9 @@ mod html_declaration_tests;
 #[path = "markdown/html_cdata_tests.rs"]
 mod html_cdata_tests;
 
+#[path = "markdown/html_processing_instruction_tests.rs"]
+mod html_processing_instruction_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -68,6 +68,9 @@ mod html_processing_instruction_tests;
 #[path = "markdown/html_comment_block_tests.rs"]
 mod html_comment_block_tests;
 
+#[path = "markdown/html_raw_content_block_tests.rs"]
+mod html_raw_content_block_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -71,6 +71,9 @@ mod html_comment_block_tests;
 #[path = "markdown/html_raw_content_block_tests.rs"]
 mod html_raw_content_block_tests;
 
+#[path = "markdown/html_standalone_tag_block_tests.rs"]
+mod html_standalone_tag_block_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -56,6 +56,9 @@ mod gfm_trio_tests;
 #[path = "markdown/hard_break_extended_tests.rs"]
 mod hard_break_extended_tests;
 
+#[path = "markdown/html_block_type_4_declaration_tests.rs"]
+mod html_block_type_4_declaration_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -65,6 +65,9 @@ mod html_cdata_tests;
 #[path = "markdown/html_processing_instruction_tests.rs"]
 mod html_processing_instruction_tests;
 
+#[path = "markdown/html_comment_block_tests.rs"]
+mod html_comment_block_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -74,6 +74,9 @@ mod html_raw_content_block_tests;
 #[path = "markdown/html_standalone_tag_block_tests.rs"]
 mod html_standalone_tag_block_tests;
 
+#[path = "markdown/html_block_element_tests.rs"]
+mod html_block_element_tests;
+
 #[path = "markdown/hard_line_break_tests.rs"]
 mod hard_line_break_tests;
 

--- a/tests/markdown/html_block_element_tests.rs
+++ b/tests/markdown/html_block_element_tests.rs
@@ -1,0 +1,244 @@
+//! Block-element HTML blocks — opener is `<NAME` or `</NAME` where
+//! NAME is one of the ~60 whitelisted block-level tags (`div`, `table`,
+//! `p`, `blockquote`, `h1`–`h6`, `ul`, `ol`, `li`, `pre`-isn't-here-it's-
+//! raw-content, etc.). Opener does NOT need to be syntactically
+//! complete; body runs to the next blank line or EOF; content is
+//! verbatim.
+//!
+//! Unlike the standalone-tag arm, this kind CAN interrupt an open
+//! paragraph — a `<div>` immediately after non-blank prose terminates
+//! the paragraph and opens a new block.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+fn html_blocks(tokens: &[Token]) -> Vec<String> {
+    tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::HtmlBlock(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn div_simple() {
+    let input = "<div>\nbody\n</div>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn table_simple() {
+    let input = "<table>\n<tr><td>x</td></tr>\n</table>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn paragraph_p_tag() {
+    // `<p>` is in the whitelist — line-start `<p>` opens a block.
+    let input = "<p>body</p>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn hr_tag() {
+    // `<hr>` is whitelisted.
+    let input = "<hr>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn heading_tags_h1_through_h6() {
+    for n in 1..=6 {
+        let input = format!("<h{}>title</h{}>\n", n, n);
+        let tokens = parse(&input);
+        assert_eq!(first_html_block(&tokens).as_deref(), Some(input.as_str()));
+    }
+}
+
+#[test]
+fn case_insensitive_tag_name() {
+    let input = "<DIV CLASS=\"foo\">\nbody\n</DIV>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn incomplete_opener_still_triggers() {
+    // Spec example 156: `<div id="foo"` (no closing `>`) is a valid
+    // block start. Body runs to EOF.
+    let input = "<div id=\"foo\"\n*hi*\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn opener_with_multiline_attributes() {
+    // Spec example 153 shape.
+    let input = "<div id=\"foo\"\n  class=\"bar\">\n</div>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn opener_with_attribute_value_split_across_lines() {
+    // Spec example 154 shape.
+    let input = "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn opener_with_invalid_attribute_chars_still_triggers() {
+    // Spec example 158: `<div *???-&&&-<---` — Type 6 doesn't validate
+    // tag syntax; only the tag name + delimiter matter.
+    let input = "<div *???-&&&-<---\n*foo*\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn blank_line_terminates_block() {
+    // Spec example 155 shape: blank line inside ends the block; what
+    // follows is a separate paragraph (markdown re-enabled).
+    let tokens = parse("<div>\n*foo*\n\n*bar*\n");
+    let blocks = html_blocks(&tokens);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0], "<div>\n*foo*\n");
+    // `*bar*` should be parsed as emphasis in the following paragraph.
+    assert!(tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn blank_lines_inside_split_into_multiple_blocks_with_paragraphs_between() {
+    // Spec example 188 / 152 shape.
+    let tokens = parse("<div>\n\n*Emphasized*\n\n</div>\n");
+    let blocks = html_blocks(&tokens);
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0], "<div>\n");
+    assert_eq!(blocks[1], "</div>\n");
+    assert!(tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn no_blank_lines_keeps_everything_inside_block() {
+    // Spec example 189 / 186 shape: without blank lines markdown
+    // inside stays literal.
+    let input = "<div>\n*foo*\n</div>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn closer_then_text_outside_block() {
+    // Spec example 186: `</div>\n*foo*` — the closer doesn't end the
+    // block (only blank line does). `*foo*` stays inside the block.
+    let input = "<div>\nbar\n</div>\n*foo*\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn can_interrupt_paragraph() {
+    // Spec example 185: `Foo\n<div>...` — `<div>` opens a Type 6 block
+    // even though the previous line is non-blank prose.
+    let tokens = parse("Foo\n<div>\nbar\n</div>\n");
+    let blocks = html_blocks(&tokens);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0], "<div>\nbar\n</div>\n");
+    // `Foo` survives as text (the renderer wraps it in a paragraph).
+    assert!(Token::collect_all_text(&tokens).contains("Foo"));
+}
+
+#[test]
+fn block_with_one_space_indent() {
+    let input = " <div>\nbody\n</div>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with(" <div>"), "got {:?}", block);
+}
+
+#[test]
+fn block_with_two_space_indent_then_body_blank_then_indented_code() {
+    // Spec example 184 shape: 2-space indent on `<div>` is valid;
+    // blank line ends the block; then 4-space-indent line becomes
+    // an indented code block.
+    let tokens = parse("  <div>\n\n    <div>\n");
+    let blocks = html_blocks(&tokens);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0], "  <div>\n");
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn four_space_indent_opener_is_code_block() {
+    // The 4-space-indented `<div>` line becomes an indented code block.
+    // The subsequent `</div>` (no indent) at line start IS detected by
+    // the Type 6 arm; both can coexist in one document.
+    let tokens = parse("    <div>\nbody\n</div>\n");
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+    // And the unindented closer line opens its own Type 6 block.
+    let blocks = html_blocks(&tokens);
+    assert_eq!(blocks.len(), 1);
+    assert!(blocks[0].contains("</div>"));
+}
+
+#[test]
+fn block_inside_blockquote() {
+    let tokens = parse("> <div>\n> body\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(body.iter().any(|t| matches!(t, Token::HtmlBlock(_))));
+}
+
+#[test]
+fn many_back_to_back_blocks_with_blank_separators() {
+    // Spec example 190 shape — each tag on its own line, blank lines
+    // between, parses as many separate Type 6 blocks.
+    let tokens = parse("<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n");
+    let blocks = html_blocks(&tokens);
+    assert_eq!(blocks.len(), 5);
+}
+
+#[test]
+fn complete_element_on_one_line() {
+    // Spec example 159 shape: complete `<div><a href="bar">*foo*</a></div>`
+    // on one line is one Type 6 block (markdown inside stays literal).
+    let input = "<div><a href=\"bar\">*foo*</a></div>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn standalone_closer_opens_block() {
+    // Spec example 151: `</div>` on its own line is a valid Type 6
+    // start (closing tag, name in whitelist).
+    let input = "</div>\n*foo*\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn non_whitelist_tag_does_not_open_block_here() {
+    // `<a>` is NOT in the whitelist (it's phrasing) — falls through
+    // to the standalone-tag arm. Verify we still get an HtmlBlock
+    // (via that other arm).
+    let tokens = parse("<a href=\"x\">\nbody\n</a>\n");
+    assert!(first_html_block(&tokens).is_some());
+}

--- a/tests/markdown/html_cdata_tests.rs
+++ b/tests/markdown/html_cdata_tests.rs
@@ -1,0 +1,132 @@
+//! HTML block Type 5 — CDATA sections (CommonMark §4.6 type 5).
+//!
+//! Opener: `<![CDATA[` at line start (0–3 space indent allowed).
+//! Body: runs to `]]>` on this or a subsequent line.
+//! Content: verbatim, including the opening indent.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn cdata_single_line() {
+    let tokens = parse("<![CDATA[foo]]>\n");
+    assert_eq!(
+        first_html_block(&tokens).as_deref(),
+        Some("<![CDATA[foo]]>\n"),
+    );
+}
+
+#[test]
+fn cdata_multi_line() {
+    let input = "<![CDATA[\nline one\nline two\n]]>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn cdata_with_markdown_chars_left_literal() {
+    // Markdown-meaningful characters inside CDATA stay literal — no
+    // emphasis or code-span parsing happens within an HTML block.
+    let input = "<![CDATA[\n*not emphasis*\n`not code`\n]]>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    // And nothing emphasized leaked out.
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn cdata_with_angle_brackets_and_ampersands_inside() {
+    // The whole point of CDATA — `<`, `>`, `&` are literal data.
+    let input = "<![CDATA[a < b && c > d]]>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn cdata_with_blank_lines_inside() {
+    // Spec example 182 shape — CDATA body can contain blank lines.
+    let input = "<![CDATA[\nfirst\n\nsecond\n]]>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn cdata_followed_by_paragraph() {
+    // Spec example 182: paragraph follows the closing `]]>` line.
+    let input = "<![CDATA[\nbody\n]]>\nokay\n";
+    let tokens = parse(input);
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert_eq!(block, "<![CDATA[\nbody\n]]>\n");
+    // `okay` should still appear in the token stream as paragraph text.
+    let text = Token::collect_all_text(&tokens);
+    assert!(text.contains("okay"), "got {:?}", text);
+}
+
+#[test]
+fn cdata_with_one_space_indent() {
+    let input = " <![CDATA[foo]]>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with(" <!["), "got {:?}", block);
+}
+
+#[test]
+fn cdata_with_three_space_indent() {
+    let input = "   <![CDATA[foo]]>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with("   <!["), "got {:?}", block);
+}
+
+#[test]
+fn four_space_indent_is_code_block_not_cdata() {
+    let tokens = parse("    <![CDATA[foo]]>\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn cdata_not_at_line_start_is_inline_text() {
+    // CDATA mid-paragraph is not a block — handled by inline raw-HTML
+    // (which today falls through to text; a later commit adds inline
+    // CDATA support per CommonMark spec example 629).
+    let tokens = parse("paragraph <![CDATA[foo]]>\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn cdata_inside_blockquote() {
+    let tokens = parse("> <![CDATA[foo]]>\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(
+        body.iter().any(|t| matches!(t, Token::HtmlBlock(_))),
+        "expected HtmlBlock inside BlockQuote, got {:?}",
+        body
+    );
+}
+
+#[test]
+fn unterminated_cdata_falls_through() {
+    // No `]]>` ever appears — the would-be block is rejected so the
+    // remainder of the document isn't swallowed. The opener falls
+    // through to inline text.
+    let tokens = parse("<![CDATA[never closes\nmore text\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn cdata_with_partial_terminator_inside() {
+    // A `]` or `]]` (without `>`) inside the body should NOT close
+    // the block — the full 3-char terminator is required.
+    let input = "<![CDATA[contains ]] and ] but no closer until]]>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}

--- a/tests/markdown/html_comment_block_tests.rs
+++ b/tests/markdown/html_comment_block_tests.rs
@@ -1,0 +1,132 @@
+//! Block-level HTML comments (CommonMark §4.6 type 2).
+//!
+//! Opener: `<!--` at line start (0–3 space indent allowed).
+//! Body: runs to `-->` on this or a subsequent line.
+//! Content: verbatim, including any text on the same line after `-->`.
+//!
+//! Distinct from the INLINE comment path tested in
+//! `parse_html_comment_tests.rs`, which fires when `<!--` appears
+//! mid-paragraph and produces `Token::HtmlComment` (carrying just the
+//! comment body without delimiters).
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn single_line_comment() {
+    let input = "<!-- hello -->\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn multi_line_comment_block() {
+    let input = "<!--\nline one\nline two\n-->\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn comment_with_text_on_same_line_after_close_keeps_it_in_block() {
+    // Spec example 177: `<!-- foo -->*bar*` — the `*bar*` after `-->`
+    // is part of the block (verbatim, no emphasis), but the next line
+    // starts fresh markdown parsing.
+    let input = "<!-- foo -->*bar*\n*baz*\n";
+    let tokens = parse(input);
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert_eq!(block, "<!-- foo -->*bar*\n");
+    // *baz* on the following line IS an emphasis (paragraph).
+    assert!(tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn comment_with_markdown_chars_inside_left_literal() {
+    let input = "<!--\n*not emphasis*\n`not code`\n-->\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn comment_with_blank_lines_inside() {
+    let input = "<!--\nfirst\n\nsecond\n-->\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn comment_with_one_space_indent() {
+    let input = " <!-- foo -->\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with(" <!--"), "got {:?}", block);
+}
+
+#[test]
+fn comment_with_three_space_indent() {
+    let input = "   <!-- foo -->\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with("   <!--"), "got {:?}", block);
+}
+
+#[test]
+fn four_space_indent_is_code_block_not_comment() {
+    let tokens = parse("    <!-- foo -->\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn comment_mid_paragraph_stays_inline() {
+    // A `<!--` that doesn't start a line stays an inline HtmlComment.
+    let tokens = parse("paragraph <!-- inline -->\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::HtmlComment(_))));
+}
+
+#[test]
+fn comment_inside_blockquote() {
+    let tokens = parse("> <!-- foo -->\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(
+        body.iter().any(|t| matches!(t, Token::HtmlBlock(_))),
+        "expected HtmlBlock inside BlockQuote, got {:?}",
+        body
+    );
+}
+
+#[test]
+fn unterminated_comment_falls_through() {
+    // No `-->` ever appears — the would-be block is rejected; falls
+    // through to the inline path (which also rejects → literal text).
+    let tokens = parse("<!-- never closes\nmore text\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn comment_with_partial_terminator_inside() {
+    // A single `-` or `--` (without `>`) inside the body must NOT
+    // close the block — full 3-char `-->` is required.
+    let input = "<!-- has - and -- but no closer until -->\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn comment_followed_by_paragraph() {
+    let input = "<!-- header -->\nbody paragraph\n";
+    let tokens = parse(input);
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert_eq!(block, "<!-- header -->\n");
+    let text = Token::collect_all_text(&tokens);
+    assert!(text.contains("body paragraph"), "got {:?}", text);
+}

--- a/tests/markdown/html_declaration_tests.rs
+++ b/tests/markdown/html_declaration_tests.rs
@@ -1,0 +1,113 @@
+//! HTML block Type 4 — declarations (CommonMark §4.6 type 4).
+//!
+//! Opener: `<!LETTER…` at line start (0–3 space indent allowed).
+//! Body: runs to the first `>` on this or a subsequent line.
+//! Content: verbatim, including the opening indent.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn doctype_html() {
+    let tokens = parse("<!DOCTYPE html>\n");
+    assert_eq!(
+        first_html_block(&tokens).as_deref(),
+        Some("<!DOCTYPE html>\n"),
+    );
+}
+
+#[test]
+fn doctype_uppercase_keyword() {
+    let tokens = parse("<!DOCTYPE HTML>\n");
+    assert!(first_html_block(&tokens).is_some());
+}
+
+#[test]
+fn element_declaration() {
+    // CommonMark example 628 in INLINE context renders <!ELEMENT…> as
+    // inline raw HTML; at line start it's a Type 4 block.
+    let tokens = parse("<!ELEMENT br EMPTY>\n");
+    assert_eq!(
+        first_html_block(&tokens).as_deref(),
+        Some("<!ELEMENT br EMPTY>\n"),
+    );
+}
+
+#[test]
+fn declaration_with_attlist() {
+    let tokens = parse("<!ATTLIST foo bar CDATA #IMPLIED>\n");
+    assert!(first_html_block(&tokens).is_some());
+}
+
+#[test]
+fn declaration_with_one_space_indent() {
+    // 0–3 space indent allowed before HTML block start.
+    let tokens = parse(" <!DOCTYPE html>\n");
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    // Indent must be preserved verbatim in the block content.
+    assert!(block.starts_with(" <!"), "got {:?}", block);
+}
+
+#[test]
+fn declaration_with_three_space_indent() {
+    let tokens = parse("   <!DOCTYPE html>\n");
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert!(block.starts_with("   <!"), "got {:?}", block);
+}
+
+#[test]
+fn four_space_indent_is_code_block_not_html() {
+    // 4-space indent → indented code block beats HTML block.
+    let tokens = parse("    <!DOCTYPE html>\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn declaration_not_at_line_start_is_inline_text() {
+    // `<!DOCTYPE` mid-paragraph should NOT become a block — Types 1-7
+    // require line-start position.
+    let tokens = parse("paragraph <!DOCTYPE html>\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn declaration_inside_blockquote() {
+    // Blockquote sub-lexer strips `> ` then re-parses, so the inner
+    // `<!DOCTYPE>` should produce an HtmlBlock inside the quote.
+    let tokens = parse("> <!DOCTYPE html>\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(
+        body.iter().any(|t| matches!(t, Token::HtmlBlock(_))),
+        "expected HtmlBlock inside BlockQuote, got {:?}",
+        body
+    );
+}
+
+#[test]
+fn opener_without_letter_is_not_a_declaration() {
+    // `<!` followed by non-letter is not a Type 4 opener. The existing
+    // inline `<!--…-->` path may take over for `<!--`, but anything
+    // else should not be claimed as a block declaration.
+    let tokens = parse("<!?> not a declaration\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn unterminated_declaration_falls_through() {
+    // No `>` ever appears — the would-be block is rejected so we
+    // don't consume the rest of the document. Falls through to inline
+    // tag matching (which also rejects, so it becomes paragraph text).
+    let tokens = parse("<!DOCTYPE unterminated\nmore text\n");
+    assert!(first_html_block(&tokens).is_none());
+}

--- a/tests/markdown/html_inline_edge_tests.rs
+++ b/tests/markdown/html_inline_edge_tests.rs
@@ -1,0 +1,129 @@
+//! Inline raw-HTML edge cases — the constructs that don't fit the
+//! ordinary open/close tag shape but still pass through verbatim:
+//!
+//!   - Processing instructions: `<?…?>`
+//!   - Declarations: `<!LETTER…>`
+//!   - CDATA sections: `<![CDATA[…]]>`
+//!   - Short HTML comment forms: `<!-->` (empty body) and `<!--->`
+//!     (single-hyphen body)
+//!   - Malformed attribute quoting that should reject as text rather
+//!     than match as inline HTML.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+#[test]
+fn inline_processing_instruction() {
+    let tokens = parse("foo <?php echo 'hi'; ?>");
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::HtmlInline(s) if s.contains("<?php"))),
+        "got {:?}",
+        tokens,
+    );
+}
+
+#[test]
+fn inline_xml_processing_instruction() {
+    let tokens = parse(r#"foo <?xml version="1.0"?>"#);
+    assert!(tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))));
+}
+
+#[test]
+fn inline_declaration() {
+    let tokens = parse("foo <!ELEMENT br EMPTY>");
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::HtmlInline(s) if s.contains("ELEMENT"))),
+        "got {:?}",
+        tokens,
+    );
+}
+
+#[test]
+fn inline_cdata() {
+    let tokens = parse("foo <![CDATA[>&<]]>");
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::HtmlInline(s) if s.contains("CDATA"))),
+        "got {:?}",
+        tokens,
+    );
+}
+
+#[test]
+fn short_comment_empty_body() {
+    let tokens = parse("text <!--> tail");
+    let Some(Token::HtmlComment(body)) =
+        tokens.iter().find(|t| matches!(t, Token::HtmlComment(_)))
+    else {
+        panic!("expected HtmlComment, got {:?}", tokens);
+    };
+    assert_eq!(body, "");
+}
+
+#[test]
+fn short_comment_single_hyphen_body() {
+    let tokens = parse("text <!---> tail");
+    let Some(Token::HtmlComment(body)) =
+        tokens.iter().find(|t| matches!(t, Token::HtmlComment(_)))
+    else {
+        panic!("expected HtmlComment, got {:?}", tokens);
+    };
+    assert_eq!(body, "-");
+}
+
+#[test]
+fn unquoted_attribute_value_with_single_quote_rejected() {
+    // Per CommonMark §6.6 an unquoted value can't contain `'`, `"`,
+    // `=`, `<`, `>`, `` ` ``. `<a href=hi'>` has `'` in the value and
+    // should NOT be a valid inline tag — it falls through to text.
+    let tokens = parse("<a href=hi'>");
+    assert!(
+        !tokens
+            .iter()
+            .any(|t| matches!(t, Token::HtmlInline(s) if s.contains("href=hi"))),
+        "got {:?}",
+        tokens,
+    );
+}
+
+#[test]
+fn unclosed_double_quoted_attribute_rejected() {
+    // `<a href="hi>` — the value's opening `"` has no closing `"` on
+    // the same input. Should NOT match as inline HTML.
+    let tokens = parse("<a href=\"hi'>");
+    assert!(!tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))));
+}
+
+#[test]
+fn pi_inside_inline_text() {
+    // Surrounding text preserved as Text tokens.
+    let tokens = parse("before <?php ?> after");
+    let text = Token::collect_all_text(&tokens);
+    assert!(text.contains("before"));
+    assert!(text.contains("after"));
+    assert!(tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))));
+}
+
+#[test]
+fn unterminated_pi_falls_through_to_text() {
+    let tokens = parse("foo <?php never closes");
+    assert!(!tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))));
+}
+
+#[test]
+fn unterminated_declaration_falls_through_to_text() {
+    let tokens = parse("foo <!ELEMENT no close");
+    assert!(!tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))));
+}
+
+#[test]
+fn unterminated_cdata_falls_through_to_text() {
+    let tokens = parse("foo <![CDATA[never closes");
+    assert!(!tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))));
+}

--- a/tests/markdown/html_processing_instruction_tests.rs
+++ b/tests/markdown/html_processing_instruction_tests.rs
@@ -1,0 +1,111 @@
+//! HTML processing-instruction blocks (CommonMark §4.6 type 3).
+//!
+//! Opener: `<?` at line start (0–3 space indent allowed).
+//! Body: runs to `?>` on this or a subsequent line.
+//! Content: verbatim, including the opening indent.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn php_pi_single_line() {
+    let input = "<?php echo 'hi'; ?>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn pi_multi_line_with_blank_inside() {
+    // Spec example 180 shape.
+    let input = "<?php\n\n  echo '>';\n\n?>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn pi_followed_by_paragraph() {
+    let input = "<?php\necho 'x';\n?>\nokay\n";
+    let tokens = parse(input);
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert_eq!(block, "<?php\necho 'x';\n?>\n");
+    let text = Token::collect_all_text(&tokens);
+    assert!(text.contains("okay"), "got {:?}", text);
+}
+
+#[test]
+fn xml_processing_instruction() {
+    let input = "<?xml version=\"1.0\"?>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn pi_with_question_marks_inside() {
+    // A bare `?` (not followed by `>`) inside the body must NOT
+    // close the block — the full 2-char `?>` terminator is required.
+    let input = "<?php is ? a single char until?>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn pi_with_markdown_chars_left_literal() {
+    let input = "<?php\n*not emphasis*\n`not code`\n?>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn pi_with_one_space_indent() {
+    let input = " <?php ?>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with(" <?"), "got {:?}", block);
+}
+
+#[test]
+fn pi_with_three_space_indent() {
+    let input = "   <?php ?>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with("   <?"), "got {:?}", block);
+}
+
+#[test]
+fn four_space_indent_is_code_block_not_pi() {
+    let tokens = parse("    <?php ?>\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn pi_not_at_line_start_is_inline_text() {
+    let tokens = parse("paragraph <?php ?>\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn pi_inside_blockquote() {
+    let tokens = parse("> <?php ?>\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(
+        body.iter().any(|t| matches!(t, Token::HtmlBlock(_))),
+        "expected HtmlBlock inside BlockQuote, got {:?}",
+        body
+    );
+}
+
+#[test]
+fn unterminated_pi_falls_through() {
+    let tokens = parse("<?php never closes\nmore text\n");
+    assert!(first_html_block(&tokens).is_none());
+}

--- a/tests/markdown/html_raw_content_block_tests.rs
+++ b/tests/markdown/html_raw_content_block_tests.rs
@@ -1,0 +1,202 @@
+//! Raw-content HTML blocks — `<script>`, `<pre>`, `<style>`, `<textarea>`.
+//!
+//! Opener: one of those tag names (case-insensitive) at line start,
+//! followed by a space, tab, `>`, or end-of-line. Up to 3 spaces of
+//! indent allowed.
+//! Body: runs to the first line that contains any of the four closing
+//! tags (`</script>`, `</pre>`, `</style>`, `</textarea>`,
+//! case-insensitive), or to EOF if no closer ever appears.
+//! Content: verbatim — no markdown parsing inside.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn script_block_basic() {
+    let input = "<script>foo</script>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn pre_block_basic() {
+    let input = "<pre>foo</pre>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn style_block_basic() {
+    let input = "<style>p{color:red;}</style>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn textarea_block_basic() {
+    let input = "<textarea>type here</textarea>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn opener_with_attributes() {
+    let input = "<script type=\"text/javascript\">\ncode\n</script>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn opener_with_multiline_attributes() {
+    // Spec example 172 shape: attributes split across lines.
+    let input = "<style\n  type=\"text/css\">\nh1 {color:red;}\n</style>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn body_with_blank_lines() {
+    // Spec example 171 shape: blank lines inside body don't end the block.
+    let input = "<textarea>\n\n*foo*\n\n_bar_\n\n</textarea>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    // Markdown chars inside stay literal.
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn body_with_markdown_chars_left_literal() {
+    let input = "<script>\n*not emphasis*\n`not code`\n[not](link)\n</script>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Link { .. })));
+}
+
+#[test]
+fn case_insensitive_opener() {
+    let input = "<SCRIPT>code</SCRIPT>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn case_insensitive_closer() {
+    // Opener lowercase, closer uppercase — both must match.
+    let input = "<script>code</SCRIPT>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn closer_with_content_after_on_same_line() {
+    // Spec example 178: `</script>1. *bar*` — the whole line is part
+    // of the block, including the markdown-looking text after `</script>`.
+    let input = "<script>\nfoo\n</script>1. *bar*\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn closer_need_not_match_opener_tag() {
+    // CommonMark §4.6 explicitly says the closer "need not match the
+    // start tag" — `<script>` can be closed by `</pre>` and vice versa.
+    let input = "<script>code</pre>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn unclosed_runs_to_eof() {
+    // Spec example 173: no closer ever appears — block consumes the
+    // rest of the document.
+    let input = "<style\n  type=\"text/css\">\n\nfoo\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn block_followed_by_paragraph() {
+    let input = "<script>code</script>\nokay\n";
+    let tokens = parse(input);
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert_eq!(block, "<script>code</script>\n");
+    let text = Token::collect_all_text(&tokens);
+    assert!(text.contains("okay"), "got {:?}", text);
+}
+
+#[test]
+fn block_with_one_space_indent() {
+    let input = " <script>foo</script>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with(" <script>"), "got {:?}", block);
+}
+
+#[test]
+fn block_with_three_space_indent() {
+    let input = "   <pre>foo</pre>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with("   <pre>"), "got {:?}", block);
+}
+
+#[test]
+fn four_space_indent_is_code_block_not_raw_html() {
+    let tokens = parse("    <script>foo</script>\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn opener_mid_paragraph_stays_inline() {
+    // `<script>` not at line start should not become a block.
+    let tokens = parse("paragraph <script>code</script>\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn opener_followed_by_space_is_valid() {
+    // Opener `<pre ` (with space before `>`) is a valid block opener
+    // per spec.
+    let input = "<pre >\nbody\n</pre>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn opener_followed_by_newline_is_valid() {
+    // Opener with no attributes and a newline immediately after the
+    // tag name (no `>` on the opener line).
+    let input = "<pre\n>\nbody\n</pre>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn block_inside_blockquote() {
+    let tokens = parse("> <script>code</script>\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(
+        body.iter().any(|t| matches!(t, Token::HtmlBlock(_))),
+        "expected HtmlBlock inside BlockQuote, got {:?}",
+        body
+    );
+}
+
+#[test]
+fn tag_name_followed_by_letter_is_not_opener() {
+    // `<scripter>` is NOT a raw-content opener because `r` follows the
+    // tag name — the delimiter requirement (space/tab/`>`/newline)
+    // isn't met.
+    let tokens = parse("<scripter>code</scripter>\n");
+    assert!(first_html_block(&tokens).is_none());
+}

--- a/tests/markdown/html_standalone_tag_block_tests.rs
+++ b/tests/markdown/html_standalone_tag_block_tests.rs
@@ -1,0 +1,183 @@
+//! Standalone HTML tag blocks — a complete open or close tag on its
+//! own line whose tag name is NOT in the raw-content set
+//! (`script/pre/style/textarea`) and NOT in the block-element whitelist
+//! (`div/table/p/…`).
+//!
+//! Opener: `<tag>` or `</tag>` at line start (0–3 space indent allowed),
+//! the tag must fit on a single line, and only spaces/tabs may follow
+//! before end-of-line.
+//! Body: runs until the next blank line or EOF; content is verbatim.
+//!
+//! Critically, this kind CANNOT interrupt an open paragraph — a line
+//! like `<a href="x">` immediately after non-blank prose stays as
+//! paragraph continuation, not a new block.
+
+use markdown2pdf::markdown::*;
+
+use super::common::parse;
+
+fn first_html_block(tokens: &[Token]) -> Option<String> {
+    tokens.iter().find_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn anchor_block_with_body() {
+    let input = "<a href=\"foo\">\n*bar*\n</a>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+    // Body markdown chars stay literal — no emphasis emitted.
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn italic_phrasing_tag_block() {
+    let input = "<i class=\"foo\">\n*bar*\n</i>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn del_phrasing_tag_block() {
+    let input = "<del>\n*foo*\n</del>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn custom_tag_block() {
+    // A custom-element tag name not in any whitelist.
+    let input = "<Warning>\n*bar*\n</Warning>\n";
+    let tokens = parse(input);
+    assert_eq!(first_html_block(&tokens).as_deref(), Some(input));
+}
+
+#[test]
+fn closing_tag_alone_opens_block() {
+    // `</ins>` at line start opens its own standalone-tag block.
+    let input = "</ins>\n*bar*\n";
+    let tokens = parse(input);
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert!(block.starts_with("</ins>"), "got {:?}", block);
+}
+
+#[test]
+fn blank_line_separates_two_standalone_blocks() {
+    // `<del>` then blank line then markdown then blank then `</del>`:
+    // becomes two separate HTML blocks plus a paragraph between them.
+    let input = "<del>\n\n*foo*\n\n</del>\n";
+    let tokens = parse(input);
+    let blocks: Vec<&String> = tokens.iter().filter_map(|t| match t {
+        Token::HtmlBlock(s) => Some(s),
+        _ => None,
+    }).collect();
+    assert_eq!(blocks.len(), 2, "expected 2 HtmlBlocks, got {:?}", blocks);
+    assert!(blocks[0].contains("<del>"));
+    assert!(blocks[1].contains("</del>"));
+    // The middle paragraph has an emphasis.
+    assert!(tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
+}
+
+#[test]
+fn tag_followed_by_non_whitespace_does_not_open_block() {
+    // `<a>x` on a line — after the complete tag there's `x` (not
+    // whitespace), so the line isn't a standalone-tag block.
+    let tokens = parse("<a>x\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn cannot_interrupt_open_paragraph() {
+    // `Foo` on line 1 starts a paragraph; `<a href="x">` on line 2
+    // looks like it could open a block, but the precedence rule says
+    // standalone tags can't interrupt paragraphs.
+    let tokens = parse("Foo\n<a href=\"x\">\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn does_open_after_blank_line() {
+    // Same tag, but with a blank line before it — now it opens a block.
+    let tokens = parse("Foo\n\n<a href=\"x\">\n");
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert!(block.starts_with("<a href"), "got {:?}", block);
+}
+
+#[test]
+fn multi_line_tag_does_not_open_block() {
+    // Tag attribute value spans onto a continuation line — the tag
+    // itself isn't on a single line, so per spec it's NOT a Type 7
+    // block. Stays as inline HTML inside a paragraph (or text).
+    let tokens = parse("<a href=\"foo  \nbar\">\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn block_element_tag_name_does_not_open_block_here() {
+    // `<a>` is fine for standalone-tag; `<div>` is NOT — it's reserved
+    // for the block-element arm (different precedence + opener rules).
+    // Until that arm lands `<div>` falls through to inline HTML.
+    let tokens = parse("<div>\n*foo*\n</div>\n");
+    assert!(first_html_block(&tokens).is_none());
+}
+
+#[test]
+fn raw_content_tag_name_does_not_open_block_here() {
+    // `<script>` is reserved for the raw-content arm (handled by an
+    // earlier check) — the standalone-tag arm shouldn't claim it.
+    // We still get an HtmlBlock here, but from the raw-content arm —
+    // verify by checking the block contains `</script>`.
+    let tokens = parse("<script>code</script>\n");
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert!(block.contains("</script>"));
+}
+
+#[test]
+fn block_with_one_space_indent() {
+    // The opener line must be followed only by whitespace, so use a
+    // tag that's alone on its line.
+    let input = " <a href=\"x\">\nbody\n</a>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with(" <a "), "got {:?}", block);
+}
+
+#[test]
+fn block_with_three_space_indent() {
+    let input = "   <a href=\"x\">\nbody\n</a>\n";
+    let block = first_html_block(&parse(input)).expect("expected HtmlBlock");
+    assert!(block.starts_with("   <a "), "got {:?}", block);
+}
+
+#[test]
+fn four_space_indent_is_code_block_not_html() {
+    let tokens = parse("    <a href=\"x\">\nbody\n</a>\n");
+    assert!(first_html_block(&tokens).is_none());
+    assert!(tokens.iter().any(|t| matches!(t, Token::Code { block: true, .. })));
+}
+
+#[test]
+fn block_inside_blockquote() {
+    let tokens = parse("> <a href=\"x\">\n");
+    let Some(Token::BlockQuote(body)) = tokens.first() else {
+        panic!("expected BlockQuote, got {:?}", tokens);
+    };
+    assert!(body.iter().any(|t| matches!(t, Token::HtmlBlock(_))));
+}
+
+#[test]
+fn self_closing_tag_opens_block() {
+    let input = "<br/>\n";
+    let tokens = parse(input);
+    assert!(first_html_block(&tokens).is_some());
+}
+
+#[test]
+fn malformed_tag_does_not_open_block() {
+    // Tag with invalid attribute syntax — `try_match_html_tag_len`
+    // returns None, so the standalone-tag arm doesn't fire and the
+    // line falls through to inline / text handling.
+    let tokens = parse("<a *!@#>\n");
+    assert!(first_html_block(&tokens).is_none());
+}

--- a/tests/markdown/html_standalone_tag_block_tests.rs
+++ b/tests/markdown/html_standalone_tag_block_tests.rs
@@ -115,12 +115,17 @@ fn multi_line_tag_does_not_open_block() {
 }
 
 #[test]
-fn block_element_tag_name_does_not_open_block_here() {
-    // `<a>` is fine for standalone-tag; `<div>` is NOT — it's reserved
-    // for the block-element arm (different precedence + opener rules).
-    // Until that arm lands `<div>` falls through to inline HTML.
+fn block_element_tag_name_goes_to_block_element_arm() {
+    // `<a>` is fine for standalone-tag; `<div>` is NOT — it's claimed
+    // by the block-element arm instead. Both arms produce HtmlBlock,
+    // but their precedence + opener rules differ (block-element can
+    // interrupt a paragraph; opener can be incomplete).
     let tokens = parse("<div>\n*foo*\n</div>\n");
-    assert!(first_html_block(&tokens).is_none());
+    // Block IS produced (by the block-element arm).
+    let block = first_html_block(&tokens).expect("expected HtmlBlock");
+    assert!(block.contains("<div>"));
+    // Markdown chars inside stay literal — no emphasis emitted.
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Emphasis { .. })));
 }
 
 #[test]

--- a/tests/markdown/link_url_paren_and_autolink_tests.rs
+++ b/tests/markdown/link_url_paren_and_autolink_tests.rs
@@ -92,8 +92,12 @@ fn invalid_autolink_falls_through_as_text() {
 
 #[test]
 fn html_comment_still_parsed() {
+    // `<!--` at line start is now a block-level HtmlBlock (CommonMark
+    // §4.6 type 2). The inline HtmlComment variant fires only when the
+    // comment is preceded by other content on the same line — that's
+    // tested in parse_html_comment_tests.rs.
     let tokens = parse("<!-- comment -->");
-    assert!(matches!(tokens[0], Token::HtmlComment(_)));
+    assert!(matches!(tokens[0], Token::HtmlBlock(_)));
 }
 
 #[test]

--- a/tests/markdown/parse_html_comment_tests.rs
+++ b/tests/markdown/parse_html_comment_tests.rs
@@ -4,8 +4,11 @@ use super::common::parse;
 
 
 #[test]
-fn simple_comment() {
-    let tokens = parse("<!-- hello -->");
+fn simple_inline_comment() {
+    // INLINE comments need a non-comment prefix on the same line —
+    // a `<!--` at line start is now a block-level HtmlBlock (CommonMark
+    // §4.6 type 2), tested separately in html_comment_block_tests.rs.
+    let tokens = parse("text <!-- hello -->");
     assert!(
         tokens.iter().any(|t| matches!(t, Token::HtmlComment(_))),
         "expected HtmlComment, got {:?}",
@@ -14,16 +17,17 @@ fn simple_comment() {
 }
 
 #[test]
-fn empty_comment_body() {
-    let tokens = parse("<!---->");
+fn empty_comment_body_inline() {
+    let tokens = parse("text <!---->");
     // Either parses as an empty HtmlComment or falls back to text —
     // both are acceptable; the bar is "must not panic".
     let _ = tokens;
 }
 
 #[test]
-fn multi_line_comment() {
-    let tokens = parse("<!--\nline one\nline two\n-->");
+fn multi_line_inline_comment() {
+    // A multi-line `<!--…-->` that starts mid-paragraph stays inline.
+    let tokens = parse("text <!--\nline one\nline two\n-->");
     assert!(tokens.iter().any(|t| matches!(t, Token::HtmlComment(_))));
 }
 

--- a/tests/markdown/raw_inline_html_tests.rs
+++ b/tests/markdown/raw_inline_html_tests.rs
@@ -25,7 +25,10 @@ fn closing_tag_inline() {
 
 #[test]
 fn open_tag_with_attribute() {
-    let tokens = parse(r#"<a href="https://example.com">"#);
+    // INLINE: needs a non-tag prefix on the same line — a complete tag
+    // alone at line start is now a standalone-tag HtmlBlock. The
+    // block-level path is tested in html_standalone_tag_block_tests.rs.
+    let tokens = parse(r#"text <a href="https://example.com">"#);
     assert!(
         tokens.iter().any(|t| matches!(t, Token::HtmlInline(_))),
         "got {:?}",
@@ -35,7 +38,7 @@ fn open_tag_with_attribute() {
 
 #[test]
 fn open_tag_self_closing() {
-    let tokens = parse("<br/>");
+    let tokens = parse("text <br/>");
     assert!(
         tokens.iter().any(|t| matches!(t, Token::HtmlInline(s) if s.contains("br"))),
         "got {:?}",

--- a/tests/markdown/raw_inline_html_tests.rs
+++ b/tests/markdown/raw_inline_html_tests.rs
@@ -45,8 +45,11 @@ fn open_tag_self_closing() {
 
 #[test]
 fn html_comment_still_works() {
+    // At line start, `<!--…-->` is now a block-level HtmlBlock per
+    // CommonMark §4.6 type 2. The inline HtmlComment variant is
+    // covered separately when the comment sits mid-paragraph.
     let tokens = parse("<!-- comment -->");
-    assert!(matches!(tokens[0], Token::HtmlComment(_)));
+    assert!(matches!(tokens[0], Token::HtmlBlock(_)));
 }
 
 #[test]

--- a/tests/markdown/tests.rs
+++ b/tests/markdown/tests.rs
@@ -435,14 +435,19 @@ A paragraph with `code` and [link](url).
 
 #[test]
 fn test_html_comment_variations() {
+    // `<!--…-->` at line start now produces a block-level HtmlBlock
+    // (CommonMark §4.6 type 2) carrying the verbatim block including
+    // delimiters. Inline comments (mid-paragraph) still produce
+    // HtmlComment — see html_comment_block_tests.rs and
+    // parse_html_comment_tests.rs respectively.
     let tests = vec![
         (
             "<!-- Simple -->",
-            vec![Token::HtmlComment(" Simple ".to_string())],
+            vec![Token::HtmlBlock("<!-- Simple -->".to_string())],
         ),
         (
             "<!--Multi\nline\ncomment-->",
-            vec![Token::HtmlComment("Multi\nline\ncomment".to_string())],
+            vec![Token::HtmlBlock("<!--Multi\nline\ncomment-->".to_string())],
         ),
     ];
 

--- a/tests/spec/html_render.rs
+++ b/tests/spec/html_render.rs
@@ -70,6 +70,16 @@ fn render_blocks(tokens: &[Token], out: &mut String, in_loose_list_item: bool) {
                 out.push_str("-->\n");
                 i += 1;
             }
+            Token::HtmlBlock(content) => {
+                // HTML block content is verbatim per CommonMark §4.6.
+                // The trailing newline mirrors the spec runner's expected
+                // output for block-level constructs.
+                out.push_str(content);
+                if !content.ends_with('\n') {
+                    out.push('\n');
+                }
+                i += 1;
+            }
             // Inline tokens at this level form a paragraph (or, inside a
             // tight-list item, a bare inline run).
             _ => {
@@ -424,7 +434,8 @@ fn render_inline_token(t: &Token, out: &mut String) {
         | Token::BlockQuote(_)
         | Token::ListItem { .. }
         | Token::Table { .. }
-        | Token::TableAlignment(_) => {
+        | Token::TableAlignment(_)
+        | Token::HtmlBlock(_) => {
             // Block tokens shouldn't appear at inline position. If they do,
             // emit them as a block escape hatch.
             render_blocks(std::slice::from_ref(t), out, false);

--- a/tests/spec/html_render.rs
+++ b/tests/spec/html_render.rs
@@ -65,9 +65,19 @@ fn render_blocks(tokens: &[Token], out: &mut String, in_loose_list_item: bool) {
                 i += 1;
             }
             Token::HtmlComment(content) => {
-                out.push_str("<!--");
-                out.push_str(content);
-                out.push_str("-->\n");
+                // Short comment forms from CommonMark §6.6 round-trip
+                // to themselves rather than the wrapped `<!--body-->`
+                // shape — empty body is `<!-->`, single-hyphen body
+                // is `<!--->`.
+                match content.as_str() {
+                    "" => out.push_str("<!-->\n"),
+                    "-" => out.push_str("<!--->\n"),
+                    _ => {
+                        out.push_str("<!--");
+                        out.push_str(content);
+                        out.push_str("-->\n");
+                    }
+                }
                 i += 1;
             }
             Token::HtmlBlock(content) => {
@@ -423,11 +433,15 @@ fn render_inline_token(t: &Token, out: &mut String) {
             out.push_str(" />");
         }
         Token::HtmlInline(html) => out.push_str(html),
-        Token::HtmlComment(content) => {
-            out.push_str("<!--");
-            out.push_str(content);
-            out.push_str("-->");
-        }
+        Token::HtmlComment(content) => match content.as_str() {
+            "" => out.push_str("<!-->"),
+            "-" => out.push_str("<!--->"),
+            _ => {
+                out.push_str("<!--");
+                out.push_str(content);
+                out.push_str("-->");
+            }
+        },
         Token::HardBreak => out.push_str("<br />\n"),
         Token::Newline => out.push('\n'),
         Token::HorizontalRule => out.push_str("<hr />\n"),

--- a/tests/spec/html_render.rs
+++ b/tests/spec/html_render.rs
@@ -319,6 +319,7 @@ fn is_block_level(tok: &Token) -> bool {
             | Token::ListItem { .. }
             | Token::HorizontalRule
             | Token::Table { .. }
+            | Token::HtmlBlock(_)
     ) || is_code_block_tok(tok)
 }
 

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 607/652 passing (93.1%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 608/652 passing (93.3%). All remaining gaps are HTML / Raw-HTML (marked O).
 
 # --- ATX headings (0 failing) ---
 
@@ -21,7 +21,7 @@
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (38 failing, all O) ---
+# --- HTML blocks (37 failing, all O) ---
 148  # O
 149  # O
 150  # O
@@ -52,7 +52,6 @@
 177  # O
 178  # O
 180  # O
-182  # O
 184  # O
 185  # O
 186  # O

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 610/652 passing (93.6%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 617/652 passing (94.6%). All remaining gaps are HTML / Raw-HTML (marked O).
 
 # --- ATX headings (0 failing) ---
 
@@ -21,7 +21,7 @@
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (35 failing, all O) ---
+# --- HTML blocks (28 failing, all O) ---
 148  # O
 149  # O
 150  # O
@@ -42,14 +42,7 @@
 165  # O
 166  # O
 167  # O
-169  # O
-170  # O
-171  # O
-172  # O
-173  # O
 174  # O
-176  # O
-178  # O
 184  # O
 185  # O
 186  # O

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 647/652 passing (99.2%). Remaining gaps are inline raw-HTML edges.
+# Last measured: 652/652 passing (100.0%). All CommonMark 0.31.2 examples pass.
 
 # --- ATX headings (0 failing) ---
 
@@ -39,12 +39,7 @@
 
 # --- Precedence (0 failing) ---
 
-# --- Raw HTML (5 failing, all O) ---
-620  # O
-626  # O
-627  # O
-628  # O
-629  # O
+# --- Raw HTML (0 failing) ---
 
 # --- Setext headings (0 failing) ---
 

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 609/652 passing (93.4%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 610/652 passing (93.6%). All remaining gaps are HTML / Raw-HTML (marked O).
 
 # --- ATX headings (0 failing) ---
 
@@ -21,7 +21,7 @@
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (36 failing, all O) ---
+# --- HTML blocks (35 failing, all O) ---
 148  # O
 149  # O
 150  # O
@@ -49,7 +49,6 @@
 173  # O
 174  # O
 176  # O
-177  # O
 178  # O
 184  # O
 185  # O

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,14 +1,13 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 617/652 passing (94.6%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 625/652 passing (95.9%). All remaining gaps are HTML / Raw-HTML (marked O).
 
 # --- ATX headings (0 failing) ---
 
 # --- Autolinks (0 failing) ---
 
-# --- Backslash escapes (1 failing, all O) ---
-21  # O
+# --- Backslash escapes (0 failing) ---
 
 # --- Block quotes (0 failing) ---
 
@@ -16,12 +15,11 @@
 
 # --- Emphasis and strong emphasis (0 failing) ---
 
-# --- Entity and numeric character references (1 failing, all O) ---
-31  # O
+# --- Entity and numeric character references (0 failing) ---
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (28 failing, all O) ---
+# --- HTML blocks (22 failing, all O) ---
 148  # O
 149  # O
 150  # O
@@ -36,12 +34,6 @@
 159  # O
 160  # O
 161  # O
-162  # O
-163  # O
-164  # O
-165  # O
-166  # O
-167  # O
 174  # O
 184  # O
 185  # O

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 606/652 passing (92.9%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 607/652 passing (93.1%). All remaining gaps are HTML / Raw-HTML (marked O).
 
 # --- ATX headings (0 failing) ---
 
@@ -21,7 +21,7 @@
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (39 failing, all O) ---
+# --- HTML blocks (38 failing, all O) ---
 148  # O
 149  # O
 150  # O
@@ -52,7 +52,6 @@
 177  # O
 178  # O
 180  # O
-181  # O
 182  # O
 184  # O
 185  # O

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 608/652 passing (93.3%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 609/652 passing (93.4%). All remaining gaps are HTML / Raw-HTML (marked O).
 
 # --- ATX headings (0 failing) ---
 
@@ -21,7 +21,7 @@
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (37 failing, all O) ---
+# --- HTML blocks (36 failing, all O) ---
 148  # O
 149  # O
 150  # O
@@ -51,7 +51,6 @@
 176  # O
 177  # O
 178  # O
-180  # O
 184  # O
 185  # O
 186  # O

--- a/tests/spec/known_failures.txt
+++ b/tests/spec/known_failures.txt
@@ -1,7 +1,7 @@
 # CommonMark spec examples we don't yet pass. One example number per
 # line, optional trailing `# comment`. Lines starting with `#` ignored.
 # Categories: R=lexer bug, H=renderer bug, N=normalization, O=out-of-scope (HTML)
-# Last measured: 625/652 passing (95.9%). All remaining gaps are HTML / Raw-HTML (marked O).
+# Last measured: 647/652 passing (99.2%). Remaining gaps are inline raw-HTML edges.
 
 # --- ATX headings (0 failing) ---
 
@@ -19,29 +19,7 @@
 
 # --- Fenced code blocks (0 failing) ---
 
-# --- HTML blocks (22 failing, all O) ---
-148  # O
-149  # O
-150  # O
-151  # O
-152  # O
-153  # O
-154  # O
-155  # O
-156  # O
-157  # O
-158  # O
-159  # O
-160  # O
-161  # O
-174  # O
-184  # O
-185  # O
-186  # O
-188  # O
-189  # O
-190  # O
-191  # O
+# --- HTML blocks (0 failing) ---
 
 # --- Hard line breaks (0 failing) ---
 

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -380,3 +380,91 @@ fn pathological_table_unbalanced_pipes() {
     }
     run_within_budget("pathological_table_unbalanced_pipes", s);
 }
+
+#[test]
+fn mass_html_block_div_openers() {
+    // Many block-element opener lines followed by blank-line
+    // terminators. Each pair is its own HtmlBlock; the scanner
+    // must not become quadratic in the count.
+    let n = 5_000;
+    let mut s = String::new();
+    for _ in 0..n {
+        s.push_str("<div>\nx\n</div>\n\n");
+    }
+    run_within_budget("mass_html_block_div_openers", s);
+}
+
+#[test]
+fn mass_unclosed_raw_html_blocks() {
+    // Each `<script>` opener with no matching closer would individually
+    // consume to EOF. Stacking many forces the lexer to recover after
+    // each block claims a chunk; verify no quadratic behavior.
+    let n = 1_000;
+    let mut s = String::new();
+    for i in 0..n {
+        s.push_str(&format!("<script>\nbody {}\n</script>\n\n", i));
+    }
+    run_within_budget("mass_unclosed_raw_html_blocks", s);
+}
+
+#[test]
+fn deeply_nested_html_inside_blockquote() {
+    // `> > > > <div>foo</div>` — deeply nested blockquote whose body
+    // is an HTML block. Recursion limit applies to blockquote depth.
+    let depth = 30;
+    let mut s = String::new();
+    for _ in 0..depth {
+        s.push_str("> ");
+    }
+    s.push_str("<div>\nbody\n</div>\n");
+    run_within_budget("deeply_nested_html_inside_blockquote", s);
+}
+
+#[test]
+fn pathological_html_attribute_storm() {
+    // A single open tag with many attributes — the tag matcher's
+    // attribute loop must handle this without slowing dramatically.
+    let n = 1_000;
+    let mut s = String::from("<a");
+    for i in 0..n {
+        s.push_str(&format!(" attr{}=\"value{}\"", i, i));
+    }
+    s.push_str(">\nbody\n</a>\n");
+    run_within_budget("pathological_html_attribute_storm", s);
+}
+
+#[test]
+fn mass_inline_processing_instructions() {
+    // Many inline PIs in a single paragraph. The inline-special
+    // matcher should handle each in O(its-own-length) without
+    // re-scanning prior content.
+    let n = 1_000;
+    let mut s = String::new();
+    for i in 0..n {
+        s.push_str(&format!("text <?php echo {}; ?> ", i));
+    }
+    s.push('\n');
+    run_within_budget("mass_inline_processing_instructions", s);
+}
+
+#[test]
+fn mass_html_comment_short_forms() {
+    let n = 5_000;
+    let mut s = String::new();
+    for _ in 0..n {
+        s.push_str("foo <!--> bar <!---> baz ");
+    }
+    s.push('\n');
+    run_within_budget("mass_html_comment_short_forms", s);
+}
+
+#[test]
+fn alternating_html_block_and_paragraph() {
+    // Forces repeated paragraph-interrupt-by-Type-6 decisions.
+    let n = 2_000;
+    let mut s = String::new();
+    for i in 0..n {
+        s.push_str(&format!("paragraph {}\n<div>\nbody {}\n</div>\n\n", i, i));
+    }
+    run_within_budget("alternating_html_block_and_paragraph", s);
+}


### PR DESCRIPTION
Closes the final 46 CommonMark spec gaps left by #69, taking the lexer from **92.9% to 100% (652/652)** on CommonMark 0.31.2. Adds parsing for all seven CommonMark HTML block kinds — raw-content blocks (`<script>`/`<pre>`/`<style>`/`<textarea>`), block comments, processing instructions, declarations (`<!DOCTYPE>`/`<!ELEMENT>`/etc.), CDATA sections, the ~60 whitelisted block-level tags (`<div>`/`<table>`/`<p>`/…), and standalone tag blocks (any complete tag on its own line). Inline raw HTML now also recognizes mid-paragraph processing instructions, declarations, CDATA sections, the short comment forms `<!-->` / `<!--->`, and tightens the unquoted-attribute-value scanner per spec. Introduces one new AST variant: `Token::HtmlBlock(String)` carrying verbatim block content.

PDF rendering of HTML is **intentionally deferred** — this branch is parser-only so the lexer is solid before we touch rendering. The branch landed across eight small commits (one per construct kind), each independently reviewable and verified to keep all prior tests green.

Closes #70.

## Verify

```bash
cargo test --all-targets
```

~750 markdown integration tests + 652 spec tests + 36 stress tests + 59 other unit tests, all green, zero warnings.