### PR TITLE
Feature/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,14 @@ cargo add markdown2pdf
 Or add to your Cargo.toml:
 
 ```toml
+# Minimal — local files only, no network, no SVG
 markdown2pdf = "0.4.0"
 ```
 
-### Feature Flags
+```toml
+# Full library: URL fetching + SVG rasterization
+markdown2pdf = { version = "0.4.0", features = ["fetch", "svg"] }
+```
 
 Two optional features. Both off by default.
 
@@ -77,16 +81,6 @@ Two optional features. Both off by default.
   README-style hero images and any SVG embedded via `![](path.svg)`
   or `<img src="...svg">`.
 
-```toml
-# Minimal — local files only, no network, no SVG
-markdown2pdf = "0.4.0"
-```
-
-```toml
-# Full library: URL fetching + SVG rasterization
-markdown2pdf = { version = "0.4.0", features = ["fetch", "svg"] }
-```
-
 To build the binary with URL fetching:
 
 ```bash
@@ -99,149 +93,65 @@ Or from source:
 cargo build --release --features fetch,svg
 ```
 
-## Usage
-
-The tool accepts file paths (`-p`), string content (`-s`), or URLs (`-u`) as input. Output path is specified with `-o`. Input precedence: path > url > string. Defaults to 'output.pdf'.
-
-Convert a Markdown file:
-```bash
-markdown2pdf -p "docs/resume.md" -o "resume.pdf"
-```
-
-Convert string content:
-```bash
-markdown2pdf -s "**bold text** *italic text*." -o "output.pdf"
-```
-
-Convert from URL (requires `fetch` feature):
-```bash
-markdown2pdf -u "https://raw.githubusercontent.com/user/repo/main/README.md" -o "readme.pdf"
-```
-
-Use `--verbose` for detailed output, `--quiet` for CI/CD pipelines, or `--dry-run` to validate syntax without generating PDF.
-
-## Fonts
-
-The font system supports four modes:
-
-- **Built-in fonts**: Helvetica, Times, Courier (fastest, no file I/O, works everywhere including Docker/CI with no system fonts)
-- **System fonts**: Searches standard OS font directories
-- **File paths**: Load directly from a TTF/OTF file
-- **Embedded bytes**: Load from compile-time included font data (great for GUI apps)
-
-```bash
-# Use built-in font (fastest)
-markdown2pdf -p document.md -o output.pdf
-```
-
-```bash
-# Use system font
-markdown2pdf -p document.md --default-font Georgia -o output.pdf
-```
-
-```bash
-# Use specific font file
-markdown2pdf -p document.md --default-font "/path/to/font.ttf" -o output.pdf
-```
-
-Font subsetting is enabled by default, reducing PDF size by embedding only the glyphs used in the document. A Unicode document with Arial Unicode MS produces ~45KB instead of 23MB.
-
-Built-in fonts work out of the box in any environment, including minimal Docker images (`rust:slim`, `debian:slim`, Alpine) and CI runners with no fonts installed. The library ships with embedded font metrics so no external font files are needed for Helvetica, Times, or Courier.
-
-Performance is ~20ms for standard documents with built-in fonts.
-
-## Library Usage
-
-Two main functions: `parse_into_file()` saves PDF to disk, `parse_into_bytes()` returns bytes for web services. Both parse Markdown, apply styling, and render output.
-
-Configuration uses `ConfigSource`: `Default` for built-in styling, `File("path")` for runtime loading, or `Embedded(content)` for compile-time embedding.
-
-
-```rust
-// Default styling
-parse_into_file(markdown, "output.pdf", ConfigSource::Default, None)?;
-```
-
-```rust
-// File-based configuration
-parse_into_file(markdown, "output.pdf", ConfigSource::File("config.toml"), None)?;
-```
-
-```rust
-// Embedded configuration
-const CONFIG: &str = include_str!("../config.toml");
-parse_into_file(markdown, "output.pdf", ConfigSource::Embedded(CONFIG), None)?;
-```
-
-Font configuration uses `FontConfig` for programmatic control:
-
-```rust
-use markdown2pdf::{parse_into_file, config::ConfigSource, fonts::FontConfig};
-
-let font_config = FontConfig::new()
-    .with_default_font("Georgia")
-    .with_code_font("Courier");
-
-parse_into_file(
-    markdown,
-    "output.pdf",
-    ConfigSource::Default,
-    Some(&font_config),
-)?;
-```
-
-You can also load fonts directly from embedded bytes using `FontSource`, which is useful for GUI applications or environments without filesystem access:
-
-```rust
-use markdown2pdf::{parse_into_file, config::ConfigSource, fonts::{FontConfig, FontSource}};
-
-static BODY_FONT: &[u8] = include_bytes!("path/to/body_font.ttf");
-static CODE_FONT: &[u8] = include_bytes!("path/to/code_font.ttf");
-
-let font_config = FontConfig::new()
-    .with_default_font_source(FontSource::bytes(BODY_FONT))
-    .with_code_font_source(FontSource::bytes(CODE_FONT));
-
-parse_into_file(
-    markdown,
-    "output.pdf",
-    ConfigSource::Default,
-    Some(&font_config),
-)?;
-```
-
-## Logging
-
-The library uses the [`log`](https://crates.io/crates/log) crate. No output by default. Enable with any `log`-compatible backend (e.g., `env_logger`) and set `RUST_LOG=markdown2pdf=info` or `debug` for diagnostics.
-
 ## Configuration
 
 Every visual choice — fonts, colors, page setup, headers / footers,
 table of contents, title page, alignment, per-block typography — lives
 in a TOML configuration. Six bundled themes (`default`, `github`,
-`academic`, `minimal`, `compact`, `modern`) give one-line styling, and
-per-block overrides handle the long tail.
-
-Pick a theme:
+`academic`, `minimal`, `compact`, `modern`) give one-line styling;
+per-block overrides handle the long tail; and **any value can be
+overridden per-run from the command line**, winning over the config
+file and theme.
 
 ```sh
+# A theme
 markdown2pdf -p input.md --theme github -o out.pdf
-```
 
-Or pass your own config:
-
-```sh
+# Your own config file
 markdown2pdf -p input.md -c my-config.toml -o out.pdf
+
+# Override individual values at runtime (highest priority)
+markdown2pdf -p input.md --title "Report" --font-size 11 --margin 2.5cm \
+  --page-numbers -V headings.h1.font_size_pt=28 -o out.pdf
 ```
 
-The full configuration guide with every field explained lives at
-**[`docs/Configuration.md`](docs/Configuration.md)**. The annotated
-reference config you can copy and tweak is at
-**[`docs/config.toml`](docs/config.toml)**.
+The full schema with every field explained is in
+**[`docs/Configuration.md`](docs/Configuration.md)**; an annotated,
+copy-and-tweak reference config is **[`docs/config.toml`](docs/config.toml)**.
 
-For library usage, pass a `ConfigSource::File(path)`,
-`ConfigSource::Embedded(toml_str)`, or `ConfigSource::Default` to
-`parse_into_bytes`.
+## Usage
+
+`markdown2pdf` converts a file (`-p`), a string (`-s`), or a URL
+(`-u`, requires the `fetch` build feature) to a PDF (`-o`, default
+`./output.pdf`).
+
+```bash
+markdown2pdf -p docs/resume.md -o resume.pdf
+markdown2pdf -s "**bold** *italic*." -o out.pdf
+markdown2pdf -p doc.md --theme academic --page-numbers -o out.pdf
+```
+
+`--verbose` / `--quiet` control output; `--dry-run` validates
+without writing; `--print-effective-config` prints the resolved
+style as TOML. Full flag reference, the config-override system, and
+font selection: **[`docs/CLI.md`](docs/CLI.md)**.
+
+## Library Usage
+
+`parse_into_file` writes a PDF; `parse_into_bytes` returns a
+`Vec<u8>` for web services. `ConfigSource` selects styling
+(`Default`, `Theme("github")`, `File(path)`, `Embedded(toml)`).
+
+```rust
+use markdown2pdf::{parse_into_file, config::ConfigSource};
+
+parse_into_file("# Hello".into(), "out.pdf", ConfigSource::Default, None)?;
+parse_into_file("# Doc".into(), "out.pdf", ConfigSource::Theme("academic"), None)?;
+```
+
+Pre-resolved styles + runtime overrides, fonts (name / path /
+embedded bytes), frontmatter, and the error model are covered in
+**[`docs/Library.md`](docs/Library.md)**.
 
 ## Markdown Coverage
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ For the latest git version:
 cargo install --git https://github.com/theiskaa/markdown2pdf
 ```
 
+URL input (`-u`) and SVG images are behind optional features; pass
+them to `cargo install` (see [Feature flags](#feature-flags)):
+
+```bash
+cargo install markdown2pdf --features fetch,svg
+```
+
 ### Prebuilt binaries
 
 Prebuilt versions are available in our [GitHub releases](https://github.com/theiskaa/markdown2pdf/releases/latest):
@@ -51,47 +58,38 @@ Prebuilt versions are available in our [GitHub releases](https://github.com/thei
 
 ## Install as library
 
-Add to your project:
+Add the crate to your project:
 
 ```bash
 cargo add markdown2pdf
 ```
 
-Or add to your Cargo.toml:
+Or, in `Cargo.toml`:
 
 ```toml
 # Minimal — local files only, no network, no SVG
 markdown2pdf = "0.4.0"
-```
 
-```toml
-# Full library: URL fetching + SVG rasterization
+# Or with URL fetching + SVG rasterization
 markdown2pdf = { version = "0.4.0", features = ["fetch", "svg"] }
 ```
 
-Two optional features. Both off by default.
+See [docs/Library.md](docs/Library.md) for the programmatic API.
 
-- **`fetch`** — URL fetching support for remote images and `-u` /
-  `--url` markdown input. Uses pure-Rust TLS (rustls), no
-  system-OpenSSL needed; works in `rust:slim` and Alpine. If you
-  need native-TLS for corporate certificate stores, depend on
-  `reqwest` directly with your preferred backend and Cargo will
-  unify.
-- **`svg`** — SVG image rasterization via `resvg`. Required for
-  README-style hero images and any SVG embedded via `![](path.svg)`
-  or `<img src="...svg">`.
+## Feature flags
 
-To build the binary with URL fetching:
+Two optional features, both off by default and shared by the binary
+and the library. The library enables them in `Cargo.toml`
+(`features = [...]`); the binary enables them at install or build
+time (`cargo install markdown2pdf --features fetch,svg`).
 
-```bash
-cargo install markdown2pdf --features fetch
-```
-
-Or from source:
-
-```bash
-cargo build --release --features fetch,svg
-```
+- **`fetch`** — URL input (the `-u`/`--url` flag) and remote images.
+  Uses pure-Rust TLS (rustls), so no system OpenSSL is needed; works
+  in `rust:slim` and Alpine. If you need native TLS for corporate
+  certificate stores, depend on `reqwest` directly with your
+  preferred backend and Cargo will unify the features.
+- **`svg`** — SVG image rasterization via `resvg`, for SVG embedded
+  through `![](path.svg)` or `<img src="...svg">`.
 
 ## Configuration
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,115 @@
+# Command-line usage
+
+The `markdown2pdf` binary converts a Markdown file, a string, or a remote URL into a styled PDF. Styling is resolved from a bundled theme and an optional TOML configuration, and every value in that configuration can be overridden per invocation directly on the command line. Because overrides take precedence over both the configuration file and the selected theme, most one-off documents need no configuration file at all — a theme plus a handful of flags is enough.
+
+This document covers every flag, the way styling is resolved, the font system, and the runtime override mechanism in full. The configuration schema itself — every section and field that a config file or an override can set — is documented separately in [Configuration.md](Configuration.md), with an annotated, copy-and-tweak starting point in [config.toml](config.toml).
+
+## Input and output
+
+The binary accepts exactly one input source. A Markdown file is supplied with `-p`/`--path`, a literal Markdown string with `-s`/`--string`, and a remote document with `-u`/`--url` (the latter requires a build that includes the `fetch` feature, described under [Fonts and build features](#fonts-and-build-features)). If more than one source is supplied the precedence is path, then url, then string. The output path is given with `-o`/`--output` and defaults to `./output.pdf` when omitted.
+
+Converting a file is the common case:
+
+```sh
+markdown2pdf -p notes.md -o notes.pdf
+```
+
+A string is convenient for short snippets and scripting. Note that a literal `\n` inside double quotes is not a newline to the shell; use a `$'...'` quoted string when real line breaks are required:
+
+```sh
+markdown2pdf -s $'# Title\n\nSome **bold** text.' -o title.pdf
+```
+
+Fetching directly from a URL is useful for rendering a project's README without cloning it:
+
+```sh
+markdown2pdf -u https://raw.githubusercontent.com/owner/repo/main/README.md --theme github -o readme.pdf
+```
+
+## Run modes
+
+By default the tool prints a short success line and any pre-flight validation warnings. Passing `-v`/`--verbose` expands this to include the full validation report and the resulting file size, which is helpful when diagnosing why an output is larger than expected. Passing `-q`/`--quiet` suppresses everything except errors and makes the process exit with a non-zero status on failure, which is the mode to use inside CI pipelines and shell loops. The two are mutually exclusive.
+
+The `--dry-run` flag runs the full lexer and validation pass but writes no PDF, exiting non-zero if the document fails validation. It is the fastest way to gate a commit or a build on document validity. The `--version` flag prints the binary version and exits.
+
+A folder can be batch-converted by combining quiet mode with a shell loop; the non-zero exit on failure makes the loop abort on the first bad document when `set -e` is active:
+
+```sh
+set -e
+for f in docs/*.md; do
+  markdown2pdf -p "$f" --quiet --theme compact -o "build/$(basename "${f%.md}").pdf"
+done
+```
+
+## How styling is resolved
+
+Styling is composed in layers, each able to override the one below it. The bundled `default` theme provides the baseline. A selected theme preset is layered on top of it — chosen either with `--theme NAME` or by a `theme = "NAME"` line inside a configuration file, with the command-line flag winning if both are present. The configuration file is applied next: its `[defaults]` block cascades into every block that does not set a field explicitly, and per-block sections such as `[paragraph]` or `[headings.h1]` take precedence over `[defaults]`. Command-line overrides are applied last and therefore win over everything.
+
+The six bundled presets are `default`, `github`, `academic`, `minimal`, `compact`, and `modern`. A preset is selected with `--theme`:
+
+```sh
+markdown2pdf -p input.md --theme github -o out.pdf
+```
+
+A configuration file is supplied with `-c`/`--config-path` and is parsed against the same schema as everything else, so an unknown or misspelled key produces a clear error with a "did you mean" suggestion rather than being silently ignored:
+
+```sh
+markdown2pdf -p input.md -c brand.toml -o out.pdf
+```
+
+Because the layering can be hard to reason about by inspection, `--print-effective-config` resolves the theme, the configuration file, and every override into the final style and prints it as TOML, then exits. It requires no input document and is the authoritative way to answer "what styling will actually be applied":
+
+```sh
+markdown2pdf --theme academic -V headings.h1.font_size_pt=28 --print-effective-config
+```
+
+## Fonts and build features
+
+The font system has four modes. The built-in fonts — Helvetica, Times, and Courier — require no files and render identically everywhere, including minimal Docker images and CI runners with no system fonts installed; they are the default and the fastest path. A system font is selected by name and is searched for in the standard operating-system font directories. A font file is loaded directly when the value looks like a path to a `.ttf` or `.otf`. In all cases glyph subsetting is automatic: only the glyphs that actually appear in the document are embedded, so a Unicode document set in a large CJK typeface produces a PDF measured in tens of kilobytes rather than tens of megabytes.
+
+The body font is selected with `--default-font` and the font used for code blocks and inline code with `--code-font`:
+
+```sh
+markdown2pdf -p doc.md --default-font Georgia --code-font "Courier New"
+markdown2pdf -p doc.md --default-font /usr/share/fonts/Inter.ttf
+```
+
+If non-ASCII text renders as empty boxes, the active font lacks those glyphs; switch to a Unicode-capable font such as `--default-font "Noto Sans"` or a path to a font that covers the required script.
+
+Network input via `-u` is gated behind the `fetch` build feature, which is not compiled into the default binary. Installing or building with that feature enables URL fetching and uses a pure-Rust TLS stack, so no system OpenSSL is required:
+
+```sh
+cargo install markdown2pdf --features fetch
+```
+
+## Overriding configuration at runtime
+
+Every field that a configuration file can set can also be set on the command line, where it takes precedence over both the file and the theme. There are two complementary mechanisms, and they can be mixed in a single invocation.
+
+The typed convenience flags cover the values that change most often. They are discoverable through `--help`, validated as they are parsed, and the dimension flags understand units. `--title` and `--author` set the corresponding PDF metadata. `--font-size` sets the base body size. `--margin` sets a uniform page margin on all four sides. `--page-size` accepts `A4`, `Letter`, `Legal`, `A3`, or `A5`, and `--orientation` accepts `portrait` or `landscape`. `--page-numbers` places a `page / total` counter in the footer center. A typical branded report combines several of them:
+
+```sh
+markdown2pdf -p report.md \
+  --theme academic \
+  --title "Quarterly Report" --author "Jane Doe" \
+  --font-size 11 --margin 2.5cm --page-numbers \
+  -o report.pdf
+```
+
+Dimension values are unit-aware. A bare number is interpreted in the schema's native unit — millimetres for margins and points for font size — while a suffix is converted: `25` and `25mm` are both 25 mm, `2.5cm` is 25 mm, `1in` is 25.4 mm, and `72pt` is 25.4 mm. The `--font-size` flag accepts a bare number or an explicit `pt` suffix only, since centimetre or inch type sizes are not meaningful.
+
+For everything the typed flags do not cover, the repeatable `-V KEY=VALUE` flag reaches any field in the schema. The key is a dotted path that mirrors the configuration structure exactly — `page.size`, `headings.h1.font_size_pt`, `blockquote.text_color`, and so on — and the value is interpreted as TOML. A value of `true` or `false` becomes a boolean, a value that parses as a number becomes a number, a value that begins with `[`, `{`, or a quote is passed through verbatim so that arrays and inline tables can be written directly, and anything else becomes a string, which is what makes `#RRGGBB` colors, font names, alignment keywords, and footer templates work without extra quoting:
+
+```sh
+markdown2pdf -p doc.md \
+  -V page.size=Letter \
+  -V paragraph.text_align=justify \
+  -V headings.h1.font_size_pt=28 \
+  -V blockquote.text_color=#888888 \
+  -V metadata.keywords='["rust","pdf"]' \
+  -o doc.pdf
+```
+
+Three behaviours are worth knowing in advance. The map form of `page.margins` requires all four sides, so `-V page.margins.top=25` fails with a missing-field error; use `--margin` for a uniform margin, `-V page.margins=25` for a uniform scalar, or the full array `-V "page.margins=[20,25,20,25]"` ordered top, right, bottom, left. The theme preset is selected before overrides are merged, so `-V theme=github` has no effect and `--theme github` must be used to switch presets. Finally, the numeric heuristic means a value like `-V metadata.title=2024` is sent as an integer and rejected because `title` is a string field; force a string by quoting inside the value, as in `-V 'metadata.title="2024"'`.
+
+An unknown key or an out-of-schema value never silently passes through. It surfaces as the same typed configuration error a malformed file would produce, including a suggestion for the closest valid field name, so a typo in an override is caught immediately rather than producing a wrong document.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -50,6 +50,11 @@ markdown2pdf -p input.md -c my-config.toml -o out.pdf
 Every field is optional. `theme = "github"` (or any other preset)
 inherits a known-good baseline; you override only what you care about.
 
+Any field below can also be overridden per-run from the command
+line (winning over the config file and `--theme`) — see
+[CLI.md](CLI.md#config-overrides) for `--title` / `--font-size` /
+`--margin` / `-V key=value` and the dotted-key syntax.
+
 ## How configuration resolves
 
 The renderer composes the final style by cascading values in this

--- a/docs/Library.md
+++ b/docs/Library.md
@@ -1,0 +1,138 @@
+# Library usage
+
+The crate exposes the same conversion pipeline the binary uses, so any styling achievable from the command line is achievable programmatically. The library parses Markdown into a token stream, resolves a style from a theme and optional configuration, and renders the PDF with its own in-tree engine. It is designed for embedding in web services that return PDF bytes, in build tooling that writes files, and in GUI or sandboxed applications that supply fonts and configuration as compile-time data rather than reading from disk.
+
+Add the crate with Cargo. The default build has no network or SVG support; the optional `fetch` feature enables fetching remote images over a pure-Rust TLS stack, and the optional `svg` feature enables rasterizing SVG images:
+
+```toml
+markdown2pdf = "0.4.0"
+
+# with URL fetching + SVG rasterization
+markdown2pdf = { version = "0.4.0", features = ["fetch", "svg"] }
+```
+
+## Entry points
+
+There are four conversion functions, forming a two-by-two grid: output to a file or to a byte buffer, and styling from a `ConfigSource` or from an already-resolved style. The file variants accept anything that implements `AsRef<Path>`, so a `&str`, `String`, `PathBuf`, or `&Path` all work. The final argument of every function is an optional reference to a `FontConfig`; passing `None` uses the built-in fonts.
+
+`parse_into_file` parses, styles, and writes a PDF to the given path. `parse_into_bytes` does the same but returns the PDF as a `Vec<u8>`, which is the right choice for an HTTP handler or any in-memory pipeline. The two `*_with_style` variants take a pre-resolved `ResolvedStyle` instead of a `ConfigSource`, which avoids re-resolving the configuration on every call when the style is fixed or is being reused across many documents.
+
+A minimal conversion to a file uses the default theme:
+
+```rust
+use markdown2pdf::{parse_into_file, config::ConfigSource};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let markdown = "# Hello\n\nSome **bold** text.".to_string();
+    parse_into_file(markdown, "out.pdf", ConfigSource::Default, None)?;
+    Ok(())
+}
+```
+
+A web service typically wants bytes rather than a file so it can stream the PDF back in a response without touching the filesystem:
+
+```rust
+use markdown2pdf::{parse_into_bytes, config::ConfigSource};
+
+fn render(markdown: String) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let pdf = parse_into_bytes(markdown, ConfigSource::Theme("github"), None)?;
+    Ok(pdf)
+}
+```
+
+## Selecting a style
+
+The `ConfigSource` enum chooses where styling comes from. `Default` uses the bundled `default` theme with no overrides. `Theme(name)` selects one of the bundled presets — `default`, `github`, `academic`, `minimal`, `compact`, or `modern` — by name, which lets library code pick a known-good look without carrying any TOML. `File(path)` reads and parses a TOML configuration at runtime. `Embedded(toml)` treats a string as the configuration body, which combined with `include_str!` bakes the configuration into the binary at compile time — the standard approach for containerized or read-only deployments.
+
+```rust
+use markdown2pdf::{parse_into_file, config::ConfigSource};
+
+// A bundled preset, no TOML to carry
+parse_into_file(md.clone(), "a.pdf", ConfigSource::Theme("academic"), None)?;
+
+// A configuration embedded at compile time
+const CFG: &str = include_str!("../brand.toml");
+parse_into_file(md, "b.pdf", ConfigSource::Embedded(CFG), None)?;
+```
+
+Every field these sources can set is documented in [Configuration.md](Configuration.md), with an annotated reference configuration in [config.toml](config.toml).
+
+## Pre-resolved styles and runtime overrides
+
+When the same style is applied to many documents, or when per-request overrides are needed, resolve the style once and reuse it. `load_config_strict` turns a `ConfigSource` and an optional theme name into a concrete `ResolvedStyle`, returning a typed error rather than falling back silently. The resolved style is then handed to `parse_into_bytes_with_style` or `parse_into_file_with_style` as many times as needed:
+
+```rust
+use markdown2pdf::{parse_into_bytes_with_style,
+                    config::{ConfigSource, load_config_strict}};
+
+let style = load_config_strict(ConfigSource::File("brand.toml"), Some("github"))?;
+let pdf = parse_into_bytes_with_style(markdown, style, None)?;
+```
+
+`load_config_strict_with_overrides` adds a highest-priority override layer expressed as a TOML fragment. The keys mirror the configuration schema exactly, and the layer wins over both the configuration file and the theme — this is the same mechanism the binary's `-V` flag uses, exposed for programmatic callers that want, for example, to inject a per-request title or color:
+
+```rust
+use markdown2pdf::config::{ConfigSource, load_config_strict_with_overrides};
+
+let style = load_config_strict_with_overrides(
+    ConfigSource::Theme("github"),
+    None,
+    Some("paragraph.text_align = \"justify\"\nheadings.h1.font_size_pt = 28"),
+)?;
+let pdf = markdown2pdf::parse_into_bytes_with_style(markdown, style, None)?;
+```
+
+These strict functions return a `ResolveError` describing exactly what went wrong: malformed TOML, an unknown theme, a cyclic `inherits` chain, or an I/O failure, with unknown keys carrying a closest-match suggestion. When a silent fallback is preferable to an error — for instance when a missing optional config should simply yield the default look — `load_config_from_source` logs the problem and returns the default theme instead of failing.
+
+## Fonts
+
+`FontConfig` selects the body and code fonts and is built fluently. A font may be named — resolving to a built-in (`Helvetica`, `Times`, `Courier`) or a system font — or supplied as raw bytes through `FontSource`, which is the right choice for GUI applications and sandboxed environments that cannot read the filesystem. Glyph subsetting is enabled by default, so only the glyphs used in the document are embedded.
+
+Selecting fonts by name covers the common case:
+
+```rust
+use markdown2pdf::{parse_into_file, config::ConfigSource, fonts::FontConfig};
+
+let fonts = FontConfig::new()
+    .with_default_font("Georgia")
+    .with_code_font("Courier");
+parse_into_file(md, "out.pdf", ConfigSource::Default, Some(&fonts))?;
+```
+
+Supplying fonts as embedded bytes removes any filesystem dependency entirely, which matters for single-binary GUI distribution:
+
+```rust
+use markdown2pdf::{parse_into_file, config::ConfigSource,
+                    fonts::{FontConfig, FontSource}};
+
+static BODY: &[u8] = include_bytes!("../fonts/Inter.ttf");
+static CODE: &[u8] = include_bytes!("../fonts/JetBrainsMono.ttf");
+
+let fonts = FontConfig::new()
+    .with_default_font_source(FontSource::bytes(BODY))
+    .with_code_font_source(FontSource::bytes(CODE));
+parse_into_file(md, "out.pdf", ConfigSource::Default, Some(&fonts))?;
+```
+
+## Frontmatter
+
+A YAML block delimited by `---` or a TOML block delimited by `+++` at the very top of the Markdown is consumed before lexing and folded into the document metadata. The recognized keys are `title`, `author`, `subject`, `keywords`, `creator`, and `language` (also accepted as `lang`); they override the configuration's `[metadata]` section. This requires no change at the call site — every `parse_into_*` entry point handles frontmatter transparently — so a document can carry its own title and author without the caller knowing them:
+
+```markdown
+---
+title: My Document
+author: Jane Doe
+keywords: [rust, pdf]
+---
+
+# Body starts here
+```
+
+## Errors
+
+Every entry point returns `Result<_, MdpError>`. The variants distinguish where the failure originated: `ParseError` carries a message and a one-based line and column for a lexer failure, `PdfError` covers generation and write failures and includes the offending path, `FontError` names the font that could not be loaded, `ConfigError` reports an invalid configuration, and `IoError` reports a filesystem failure with its path. Every variant also carries a human-readable suggestion. `MdpError` implements `std::error::Error` and `Display` — the `Display` output includes the suggestion — so it composes directly with `?` and `Box<dyn Error>` without any manual mapping.
+
+## Logging
+
+The library logs through the [`log`](https://crates.io/crates/log) facade and is silent unless a backend is installed. Enabling any `log`-compatible backend such as `env_logger` and setting `RUST_LOG=markdown2pdf=info`, or `debug` for more detail, surfaces diagnostics like font fallback decisions, configuration fallbacks, and validation notes without changing any code.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,10 +1,147 @@
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 use markdown2pdf::validation;
 #[cfg(feature = "fetch")]
 use reqwest::blocking::Client;
 use std::fs;
 use std::path::PathBuf;
 use std::process;
+
+/// Split a dimension token into its numeric part and unit suffix.
+/// `"2.5cm"` -> `(2.5, "cm")`, `"25"` -> `(25.0, "")`.
+fn split_num_unit(s: &str) -> Result<(f64, &str), String> {
+    let s = s.trim();
+    let idx = s
+        .find(|c: char| c.is_ascii_alphabetic() || c == '%')
+        .unwrap_or(s.len());
+    let (n, u) = s.split_at(idx);
+    let num: f64 = n
+        .trim()
+        .parse()
+        .map_err(|_| format!("`{}` is not a number", s))?;
+    Ok((num, u.trim()))
+}
+
+/// Parse a margin length to millimetres (the schema's native margin
+/// unit). Bare numbers are mm; `cm`/`mm`/`in`/`pt` are converted.
+fn parse_margin_mm(s: &str) -> Result<f64, String> {
+    let (num, unit) = split_num_unit(s)?;
+    Ok(match unit {
+        "" | "mm" => num,
+        "cm" => num * 10.0,
+        "in" => num * 25.4,
+        "pt" => num * 25.4 / 72.0,
+        other => {
+            return Err(format!(
+                "unknown length unit `{}` (use mm, cm, in, or pt)",
+                other
+            ));
+        }
+    })
+}
+
+/// Parse a font size to points (the schema's native font unit). Bare
+/// numbers and a `pt` suffix are accepted; other units are rejected.
+fn parse_font_pt(s: &str) -> Result<f64, String> {
+    let (num, unit) = split_num_unit(s)?;
+    match unit {
+        "" | "pt" => Ok(num),
+        other => Err(format!(
+            "font size unit `{}` not supported (use a bare number or `pt`)",
+            other
+        )),
+    }
+}
+
+/// Render a `-V key=VALUE` right-hand side as a TOML value. Values
+/// that already look like TOML compound/quoted literals (`[..]`,
+/// `{..}`, `"..."`) pass through verbatim so users can write
+/// arrays / inline tables. Otherwise: `true`/`false` -> bool,
+/// integer -> int, float -> float, anything else -> a quoted,
+/// escaped basic string (covers `#RRGGBB`, font names, `{page}`
+/// templates, alignment words).
+fn toml_value(v: &str) -> String {
+    let t = v.trim();
+    if (t.starts_with('[') && t.ends_with(']'))
+        || (t.starts_with('{') && t.ends_with('}'))
+        || (t.starts_with('"') && t.ends_with('"') && t.len() >= 2)
+    {
+        return t.to_string();
+    }
+    if t == "true" || t == "false" {
+        return t.to_string();
+    }
+    if t.parse::<i64>().is_ok() || t.parse::<f64>().is_ok() {
+        return t.to_string();
+    }
+    let esc = t.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{}\"", esc)
+}
+
+/// Quote + escape a string we control (typed-flag values are always
+/// strings: title, author, page size name, orientation, templates).
+fn toml_string(v: &str) -> String {
+    format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// Build a single TOML fragment from the override flags. Returns
+/// `None` when no override flag was supplied. The fragment is parsed
+/// and validated by the library against the real config schema.
+fn build_overrides(m: &clap::ArgMatches) -> Result<Option<String>, AppError> {
+    let mut lines: Vec<String> = Vec::new();
+
+    if let Some(t) = m.get_one::<String>("title") {
+        lines.push(format!("metadata.title = {}", toml_string(t)));
+    }
+    if let Some(a) = m.get_one::<String>("author") {
+        lines.push(format!("metadata.author = {}", toml_string(a)));
+    }
+    if let Some(fs_) = m.get_one::<String>("font-size") {
+        let pt = parse_font_pt(fs_).map_err(AppError::ConversionError)?;
+        lines.push(format!("defaults.font_size_pt = {}", pt));
+    }
+    if let Some(mg) = m.get_one::<String>("margin") {
+        let mm = parse_margin_mm(mg).map_err(AppError::ConversionError)?;
+        lines.push(format!(
+            "page.margins = {{ top = {mm}, right = {mm}, bottom = {mm}, left = {mm} }}"
+        ));
+    }
+    if let Some(ps) = m.get_one::<String>("page-size") {
+        lines.push(format!("page.size = {}", toml_string(ps)));
+    }
+    if let Some(o) = m.get_one::<String>("orientation") {
+        lines.push(format!("page.orientation = {}", toml_string(o)));
+    }
+    if m.get_flag("page-numbers") {
+        lines.push(format!(
+            "footer.center = {}",
+            toml_string("{page} / {total_pages}")
+        ));
+    }
+    if let Some(vars) = m.get_many::<String>("var") {
+        for kv in vars {
+            let (key, value) = kv.split_once('=').ok_or_else(|| {
+                AppError::ConversionError(format!(
+                    "-V expects KEY=VALUE, got `{}`",
+                    kv
+                ))
+            })?;
+            let key = key.trim();
+            if key.is_empty() {
+                return Err(AppError::ConversionError(format!(
+                    "-V key is empty in `{}`",
+                    kv
+                )));
+            }
+            lines.push(format!("{} = {}", key, toml_value(value)));
+        }
+    }
+
+    if lines.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(lines.join("\n")))
+    }
+}
 
 #[derive(Debug)]
 enum AppError {
@@ -25,24 +162,25 @@ enum Verbosity {
 
 fn get_markdown_input(matches: &clap::ArgMatches) -> Result<String, AppError> {
     if let Some(file_path) = matches.get_one::<String>("path") {
-        fs::read_to_string(file_path).map_err(|e| AppError::FileReadError(e))
-    } else if let Some(_url) = matches.get_one::<String>("url") {
-        #[cfg(feature = "fetch")]
-        {
-            Client::new()
-                .get(_url)
-                .send()
-                .map_err(|e| AppError::NetworkError(e.to_string()))?
-                .text()
-                .map_err(|e| AppError::NetworkError(e.to_string()))
-        }
-        #[cfg(not(feature = "fetch"))]
-        {
-            Err(AppError::ConversionError(
-                "URL fetching is not enabled. Please rebuild with --features fetch".to_string()
-            ))
-        }
-    } else if let Some(markdown_string) = matches.get_one::<String>("string") {
+        return fs::read_to_string(file_path).map_err(AppError::FileReadError);
+    }
+
+    // The `url` argument is only registered when the `fetch` feature
+    // is compiled in. Querying clap for an argument id that was never
+    // defined panics, so this whole branch must be cfg-gated — in a
+    // non-fetch build the `url` id genuinely does not exist.
+    #[cfg(feature = "fetch")]
+    if let Some(url) = matches.get_one::<String>("url") {
+        let body = Client::new()
+            .get(url)
+            .send()
+            .map_err(|e| AppError::NetworkError(e.to_string()))?
+            .text()
+            .map_err(|e| AppError::NetworkError(e.to_string()))?;
+        return Ok(body);
+    }
+
+    if let Some(markdown_string) = matches.get_one::<String>("string") {
         Ok(markdown_string.to_string())
     } else {
         Err(AppError::ConversionError("No input provided".to_string()))
@@ -71,6 +209,9 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Check for dry-run mode
     let dry_run = matches.get_flag("dry-run");
 
+    // Per-parameter CLI overrides (highest priority in the cascade).
+    let overrides = build_overrides(&matches)?;
+
     // `--print-effective-config` resolves the style and dumps it as
     // TOML; no markdown input required. Handled before any markdown
     // I/O so users can inspect the effective config in isolation.
@@ -80,8 +221,12 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
             None => markdown2pdf::config::ConfigSource::Default,
         };
         let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
-        let style = markdown2pdf::config::load_config_strict(config_source, theme_override)
-            .map_err(|e| AppError::ConversionError(e.to_string()))?;
+        let style = markdown2pdf::config::load_config_strict_with_overrides(
+            config_source,
+            theme_override,
+            overrides.as_deref(),
+        )
+        .map_err(|e| AppError::ConversionError(e.to_string()))?;
         let toml = toml::to_string_pretty(&style)
             .map_err(|e| AppError::ConversionError(e.to_string()))?;
         println!("{}", toml);
@@ -170,8 +315,12 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
         None => markdown2pdf::config::ConfigSource::Default,
     };
     let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
-    let resolved_style = markdown2pdf::config::load_config_strict(config_source, theme_override)
-        .map_err(|e| AppError::ConversionError(e.to_string()))?;
+    let resolved_style = markdown2pdf::config::load_config_strict_with_overrides(
+        config_source,
+        theme_override,
+        overrides.as_deref(),
+    )
+    .map_err(|e| AppError::ConversionError(e.to_string()))?;
 
     markdown2pdf::parse_into_file_with_style(
         markdown,
@@ -203,12 +352,31 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
 fn main() {
     let cmd = Command::new("markdown2pdf")
         .version(env!("CARGO_PKG_VERSION"))
-        .about("Convert Markdown files or strings to PDF")
+        // `-V` is freed from clap's auto version flag (pandoc parity)
+        // and reused for `--var` overrides; `--version` stays as a
+        // long-only flag.
+        .disable_version_flag(true)
+        .arg(
+            Arg::new("version")
+                .long("version")
+                .help("Print version and exit")
+                .action(ArgAction::Version),
+        )
+        .about("Markdown to PDF transpiler")
         .after_help(
             "EXAMPLES:\n  \
             markdown2pdf -p document.md -o output.pdf\n  \
             markdown2pdf -s \"# Hello World\" --default-font Georgia\n  \
-            markdown2pdf -p doc.md --verbose --dry-run\n",
+            markdown2pdf -p doc.md --theme github --page-numbers\n  \
+            markdown2pdf -p doc.md --title \"Report\" --font-size 11 --margin 2.5cm\n  \
+            markdown2pdf -p doc.md -V blockquote.text_color=#888888 -V headings.h1.font_size_pt=28\n\
+            \nCONFIG OVERRIDES:\n  \
+            Typed flags and -V KEY=VALUE override the config file and\n  \
+            --theme at runtime. -V keys mirror the TOML schema (dotted),\n  \
+            e.g. -V page.size=Letter -V paragraph.text_align=justify.\n  \
+            Dimensions accept cm/mm/in/pt; a bare number is mm (margins)\n  \
+            or pt (font size). Note: -V page.margins.top=N needs all four\n  \
+            sides; use --margin or -V page.margins=N (uniform) instead.\n",
         )
         .arg(
             Arg::new("path")
@@ -301,6 +469,60 @@ fn main() {
                 .long("print-effective-config")
                 .help("Print the fully-resolved style as TOML and exit")
                 .action(clap::ArgAction::SetTrue),
+        )
+        .next_help_heading("Config overrides (win over config file & --theme)")
+        .arg(
+            Arg::new("title")
+                .long("title")
+                .value_name("TEXT")
+                .help("Document title (PDF metadata)"),
+        )
+        .arg(
+            Arg::new("author")
+                .long("author")
+                .value_name("TEXT")
+                .help("Document author (PDF metadata)"),
+        )
+        .arg(
+            Arg::new("font-size")
+                .long("font-size")
+                .value_name("SIZE")
+                .help("Base body font size, e.g. 11 or 11pt"),
+        )
+        .arg(
+            Arg::new("margin")
+                .long("margin")
+                .value_name("LEN")
+                .help("Uniform page margin, e.g. 25, 25mm, 2.5cm, 1in"),
+        )
+        .arg(
+            Arg::new("page-size")
+                .long("page-size")
+                .value_name("NAME")
+                .help("Page size: A4 | Letter | Legal | A3 | A5"),
+        )
+        .arg(
+            Arg::new("orientation")
+                .long("orientation")
+                .value_name("DIR")
+                .help("Page orientation: portrait | landscape"),
+        )
+        .arg(
+            Arg::new("page-numbers")
+                .long("page-numbers")
+                .help("Add `page / total` to the footer center")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("var")
+                .short('V')
+                .long("var")
+                .value_name("KEY=VALUE")
+                .action(ArgAction::Append)
+                .help(
+                    "Override any config field (dotted TOML key), repeatable. \
+                     e.g. -V page.size=Letter -V headings.h1.font_size_pt=28",
+                ),
         );
 
     let matches = cmd.clone().get_matches();
@@ -330,5 +552,64 @@ fn main() {
             AppError::NetworkError(e) => eprintln!("[X] Network error: {}", e),
         }
         process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn margin_units_convert_to_mm() {
+        assert_eq!(parse_margin_mm("25").unwrap(), 25.0);
+        assert_eq!(parse_margin_mm("25mm").unwrap(), 25.0);
+        assert_eq!(parse_margin_mm("2.5cm").unwrap(), 25.0);
+        assert_eq!(parse_margin_mm("1in").unwrap(), 25.4);
+        assert!((parse_margin_mm("72pt").unwrap() - 25.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn margin_rejects_unknown_unit() {
+        assert!(parse_margin_mm("2.5furlongs").is_err());
+        assert!(parse_margin_mm("abc").is_err());
+    }
+
+    #[test]
+    fn font_size_accepts_bare_and_pt_only() {
+        assert_eq!(parse_font_pt("11").unwrap(), 11.0);
+        assert_eq!(parse_font_pt("11pt").unwrap(), 11.0);
+        assert!(parse_font_pt("11cm").is_err());
+        assert!(parse_font_pt("x").is_err());
+    }
+
+    #[test]
+    fn toml_value_typing_heuristic() {
+        assert_eq!(toml_value("true"), "true");
+        assert_eq!(toml_value("false"), "false");
+        assert_eq!(toml_value("28"), "28");
+        assert_eq!(toml_value("11.5"), "11.5");
+        // hex color -> quoted string
+        assert_eq!(toml_value("#888888"), "\"#888888\"");
+        // alignment word -> quoted string
+        assert_eq!(toml_value("justify"), "\"justify\"");
+        // arrays / inline tables / pre-quoted pass through verbatim
+        assert_eq!(toml_value("[20,25,20,25]"), "[20,25,20,25]");
+        assert_eq!(toml_value("{ top = 1 }"), "{ top = 1 }");
+        assert_eq!(toml_value("\"already\""), "\"already\"");
+    }
+
+    #[test]
+    fn toml_string_escapes() {
+        assert_eq!(toml_string("plain"), "\"plain\"");
+        assert_eq!(toml_string("a\"b"), "\"a\\\"b\"");
+        assert_eq!(toml_string("a\\b"), "\"a\\\\b\"");
+    }
+
+    #[test]
+    fn split_num_unit_basic() {
+        assert_eq!(split_num_unit("2.5cm").unwrap(), (2.5, "cm"));
+        assert_eq!(split_num_unit("25").unwrap(), (25.0, ""));
+        assert_eq!(split_num_unit(" 11 pt ").unwrap(), (11.0, "pt"));
+        assert!(split_num_unit("cm").is_err());
     }
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -5,7 +5,9 @@
 //! lower to `ResolvedStyle`. Errors surface through
 //! [`styling::ResolveError`].
 
-use crate::styling::{DocumentConfig, ResolveError, ResolvedStyle, merge::resolve};
+use crate::styling::{
+    DocumentConfig, ResolveError, ResolvedStyle, merge::resolve_with_overrides,
+};
 use std::fs;
 use std::path::Path;
 
@@ -38,13 +40,52 @@ pub fn load_config_strict(
     source: ConfigSource,
     theme_override: Option<&str>,
 ) -> Result<ResolvedStyle, ResolveError> {
+    load_config_strict_with_overrides(source, theme_override, None)
+}
+
+/// Like [`load_config_strict`], but applies `overrides_toml` (a TOML
+/// fragment, typically built from CLI flags) as the highest-priority
+/// layer — winning over the config file *and* `--theme`. The fragment
+/// is parsed through the **same** schema + typo-suggestion error path
+/// as a real config file, so an unknown key surfaces as
+/// [`ResolveError::BadToml`] with a hint. `None` is equivalent to
+/// [`load_config_strict`].
+pub fn load_config_strict_with_overrides(
+    source: ConfigSource,
+    theme_override: Option<&str>,
+    overrides_toml: Option<&str>,
+) -> Result<ResolvedStyle, ResolveError> {
+    // Parse the override fragment once, reusing the config-file error
+    // mapping (unknown key → BadToml + suggestion).
+    let overrides: Option<DocumentConfig> = match overrides_toml {
+        Some(text) if !text.trim().is_empty() => {
+            let parsed = toml::from_str(text).map_err(|source| {
+                let suggestion =
+                    crate::styling::error::unknown_field_suggestion(source.message());
+                ResolveError::BadToml {
+                    source,
+                    file: None,
+                    suggestion,
+                }
+            })?;
+            Some(parsed)
+        }
+        _ => None,
+    };
+
     let (toml_text, file_for_errors) = match source {
-        ConfigSource::Default => return resolve(DocumentConfig::default(), theme_override),
+        ConfigSource::Default => {
+            return resolve_with_overrides(
+                DocumentConfig::default(),
+                theme_override,
+                overrides,
+            );
+        }
         ConfigSource::Theme(name) => {
             // CLI `--theme` semantics: caller-supplied theme_override
             // still wins so a user can layer overrides on top.
             let theme = theme_override.or(Some(name));
-            return resolve(DocumentConfig::default(), theme);
+            return resolve_with_overrides(DocumentConfig::default(), theme, overrides);
         }
         ConfigSource::File(path) => {
             let p = Path::new(path).to_path_buf();
@@ -66,7 +107,7 @@ pub fn load_config_strict(
         }
     })?;
 
-    resolve(user, theme_override)
+    resolve_with_overrides(user, theme_override, overrides)
 }
 
 /// Soft-fail version of [`load_config_strict`]. On any error logs a
@@ -173,5 +214,131 @@ mod tests {
             None,
         );
         assert!(matches!(err, Err(ResolveError::BadToml { .. })));
+    }
+
+    // --- CLI override layer (issue #67) -----------------------------
+
+    #[test]
+    fn overrides_none_equals_no_overrides() {
+        let a = load_config_strict(ConfigSource::Default, None).unwrap();
+        let b =
+            load_config_strict_with_overrides(ConfigSource::Default, None, None).unwrap();
+        assert_eq!(a.paragraph.font_size_pt, b.paragraph.font_size_pt);
+        assert_eq!(a.headings[0].font_size_pt, b.headings[0].font_size_pt);
+    }
+
+    #[test]
+    fn override_beats_embedded_config_file() {
+        // Config file sets paragraph 9pt; the override sets the same
+        // per-block key to 11pt and must win.
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Embedded("[paragraph]\nfont_size_pt = 9.0\n"),
+            None,
+            Some("paragraph.font_size_pt = 11.0"),
+        )
+        .unwrap();
+        assert_eq!(style.paragraph.font_size_pt, 11.0);
+    }
+
+    #[test]
+    fn override_beats_theme_preset() {
+        // github theme sets paragraph 10pt; override forces 13pt.
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Theme("github"),
+            None,
+            Some("defaults.font_size_pt = 13.0"),
+        )
+        .unwrap();
+        assert_eq!(style.paragraph.font_size_pt, 13.0);
+    }
+
+    #[test]
+    fn override_dotted_heading_key() {
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            None,
+            Some("headings.h1.font_size_pt = 28.0"),
+        )
+        .unwrap();
+        assert_eq!(style.headings[0].font_size_pt, 28.0);
+    }
+
+    #[test]
+    fn override_color_value() {
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            None,
+            Some("blockquote.text_color = \"#888888\""),
+        )
+        .unwrap();
+        assert_eq!(
+            style.blockquote.text_color,
+            crate::styling::Color::rgb(0x88, 0x88, 0x88)
+        );
+    }
+
+    #[test]
+    fn override_uniform_margins_scalar() {
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            None,
+            Some("page.margins = 25.0"),
+        )
+        .unwrap();
+        assert_eq!(style.page.margins_mm.top, 25.0);
+        assert_eq!(style.page.margins_mm.left, 25.0);
+    }
+
+    #[test]
+    fn override_metadata_and_footer() {
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            None,
+            Some(
+                "metadata.title = \"My Report\"\n\
+                 footer.center = \"{page} / {total_pages}\"",
+            ),
+        )
+        .unwrap();
+        assert_eq!(style.metadata.title.as_deref(), Some("My Report"));
+        assert_eq!(
+            style.footer.as_ref().and_then(|f| f.center.clone()),
+            Some("{page} / {total_pages}".to_string())
+        );
+    }
+
+    #[test]
+    fn invalid_override_key_is_typed_error_not_panic() {
+        let err = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            None,
+            Some("bogus.key = 1"),
+        );
+        assert!(matches!(err, Err(ResolveError::BadToml { .. })));
+    }
+
+    #[test]
+    fn empty_override_fragment_is_noop() {
+        let a = load_config_strict(ConfigSource::Default, None).unwrap();
+        let b = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            None,
+            Some("   \n  "),
+        )
+        .unwrap();
+        assert_eq!(a.paragraph.font_size_pt, b.paragraph.font_size_pt);
+    }
+
+    #[test]
+    fn override_layers_on_top_of_theme_override_arg() {
+        // theme_override (the --theme flag) selects github; the
+        // overlay still wins for the field it sets.
+        let style = load_config_strict_with_overrides(
+            ConfigSource::Default,
+            Some("github"),
+            Some("defaults.font_size_pt = 7.5"),
+        )
+        .unwrap();
+        assert_eq!(style.paragraph.font_size_pt, 7.5);
     }
 }

--- a/src/lib/styling/merge.rs
+++ b/src/lib/styling/merge.rs
@@ -27,12 +27,28 @@ pub fn resolve(
     user: DocumentConfig,
     theme_override: Option<&str>,
 ) -> Result<ResolvedStyle, ResolveError> {
+    resolve_with_overrides(user, theme_override, None)
+}
+
+/// Like [`resolve`], but applies `overrides` as the highest-priority
+/// layer — on top of the theme preset *and* the user config. Used by
+/// the CLI so per-parameter flags win over the config file and
+/// `--theme`. The cascade is therefore:
+/// `preset → user config → overrides`.
+pub fn resolve_with_overrides(
+    user: DocumentConfig,
+    theme_override: Option<&str>,
+    overrides: Option<DocumentConfig>,
+) -> Result<ResolvedStyle, ResolveError> {
     let theme_name = theme_override
         .map(str::to_string)
         .or_else(|| user.theme.clone())
         .unwrap_or_else(|| "default".to_string());
     let preset = load_theme_preset(&theme_name)?;
-    let merged = merge_documents(preset, user);
+    let mut merged = merge_documents(preset, user);
+    if let Some(ov) = overrides {
+        merged = merge_documents(merged, ov);
+    }
     lower(&theme_name, merged)
 }
 


### PR DESCRIPTION
Resolves #67: the CLI could previously only pick a config file or a theme. This adds a runtime override layer so any configuration value can be set per invocation from the command line, taking precedence over both the config file and the selected theme. It also restructures the documentation around the now much larger CLI surface.