### PR TITLE
Bugfix/font weight rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ font that is loaded and embedded, not just `--default-font`.
 `[list.common]` sets the gap between a bullet and its text; defaults
 to the previous `5.67` pt.
 
+**Config file discovery.** With no `-c` flag, the CLI now finds a
+config automatically — `MARKDOWN2PDF_CONFIG`, then `./markdown2pdf.toml`,
+then `~/.config/markdown2pdf/config.toml` — before the default theme.
+
+**Link underline honours config.** `[link].underline = false` now
+suppresses the link underline; it was previously forced on regardless
+of the configured style.
+
 Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81) and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
 
 ## [1.3.0] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,20 @@ through the same transliteration the emit path uses, so the two
 agree exactly. Documents with no transliterated characters, and any
 document rendered with a Unicode font, are unaffected.
 
-Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81)
-and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
+**Font weight fixes.** System-font lookup could return a bold face
+(e.g. `Tahoma Bold.ttf`) as the regular weight, rendering the whole
+document heavy; an exact filename match now wins. Heading bold, which
+comes from the style block rather than run flags, is now applied, and
+the bold/italic faces it needs are embedded for external fonts.
+
+**Config-driven body font.** `[defaults].font_family` now selects the
+font that is loaded and embedded, not just `--default-font`.
+
+**Configurable list bullet gap.** New `bullet_gap_pt` on
+`[list.common]` sets the gap between a bullet and its text; defaults
+to the previous `5.67` pt.
+
+Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81) and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
 
 ## [1.3.0] - 2026-05-20
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,8 @@ A configuration file is supplied with `-c`/`--config-path` and is parsed against
 markdown2pdf -p input.md -c brand.toml -o out.pdf
 ```
 
+When `-c` is omitted the binary looks for a configuration file automatically, in this order: the path in the `MARKDOWN2PDF_CONFIG` environment variable, then `markdown2pdf.toml` in the current directory (per-project), then `markdown2pdf/config.toml` under the user config directory (`$XDG_CONFIG_HOME`, else `~/.config`, else `%APPDATA%`). The first file that exists is used; if none is found the bundled `default` theme applies. An explicit `-c` always wins over discovery. A discovered path is reported under `--verbose`.
+
 Because the layering can be hard to reason about by inspection, `--print-effective-config` resolves the theme, the configuration file, and every override into the final style and prints it as TOML, then exits. It requires no input document and is the authoritative way to answer "what styling will actually be applied":
 
 ```sh

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -122,6 +122,7 @@ margin_after_pt = 0.5
 indent_per_level_pt = 17.0
 item_spacing_tight_pt = 0.5
 item_spacing_loose_pt = 2.0
+bullet_gap_pt = 5.67          # gap between the bullet/number and the text
 
 [list.unordered]
 bullet = "•"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,18 @@ indent_pt = 0.0
 fallback_fonts = ["Noto Sans CJK SC", "Noto Sans Arabic", "Symbola"]
 ```
 
+### Body font
+
+`font_family` in `[defaults]` selects the font that is loaded and
+embedded — a built-in alias (`Helvetica`, `Times`, `Courier`), a system
+font name, or a path to a `.ttf` / `.otf` file. A built-in alias uses a
+PDF base-14 font (no embedding; non-ASCII glyphs transliterate to
+ASCII). Any other name is resolved against the system font directories
+and embedded, which is required for Unicode glyphs such as `•`.
+
+The `--default-font` CLI flag overrides this; when it is omitted the
+config's `font_family` is used.
+
 ### Fallback fonts
 
 `fallback_fonts` is an ordered list of font names consulted when the
@@ -235,6 +247,7 @@ margin_after_pt = 0.5
 indent_per_level_pt = 17.0
 item_spacing_tight_pt = 0.5  # CommonMark "tight" list (no blank lines)
 item_spacing_loose_pt = 2.0  # CommonMark "loose" list (any blank line)
+bullet_gap_pt = 5.67         # horizontal gap between the bullet/number and the item text
 
 [list.unordered]
 bullet = "•"   # any glyph

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,13 @@ markdown2pdf -p input.md -c my-config.toml -o out.pdf
 Every field is optional. `theme = "github"` (or any other preset)
 inherits a known-good baseline; you override only what you care about.
 
+To make a config the default without passing `-c` every time, place
+it where the binary discovers it automatically: `markdown2pdf.toml`
+in the project directory, or `markdown2pdf/config.toml` under your
+user config directory (`~/.config/markdown2pdf/config.toml` on
+macOS/Linux). The `MARKDOWN2PDF_CONFIG` environment variable also
+points at one. See [cli.md](cli.md) for the full lookup order.
+
 Any field below can also be overridden per-run from the command
 line (winning over the config file and `--theme`) — see
 [cli.md](cli.md#config-overrides) for `--title` / `--font-size` /

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -196,6 +196,35 @@ fn get_output_path(matches: &clap::ArgMatches) -> Result<PathBuf, AppError> {
         .unwrap_or_else(|| current_dir.join("output.pdf")))
 }
 
+/// Locate a config file when `-c` was not given, in precedence order:
+/// the `MARKDOWN2PDF_CONFIG` env var, `./markdown2pdf.toml` in the
+/// working directory, then the per-user config. Returns the first
+/// that exists; `None` falls back to the built-in default theme.
+fn discover_config_file() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("MARKDOWN2PDF_CONFIG") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let project = PathBuf::from("markdown2pdf.toml");
+    if project.is_file() {
+        return Some(project);
+    }
+    user_config_file().filter(|p| p.is_file())
+}
+
+/// `<config-dir>/markdown2pdf/config.toml`, where the config dir is
+/// `XDG_CONFIG_HOME`, else `~/.config`, else `%APPDATA%`.
+fn user_config_file() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .or_else(|| std::env::var_os("APPDATA").map(PathBuf::from))?;
+    Some(base.join("markdown2pdf").join("config.toml"))
+}
+
 fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Determine verbosity level
     let verbosity = if matches.get_flag("quiet") {
@@ -212,14 +241,25 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Per-parameter CLI overrides (highest priority in the cascade).
     let overrides = build_overrides(&matches)?;
 
+    // Pick the config file once, so `--print-effective-config` and a
+    // real render agree. An explicit -c wins; otherwise discover one
+    // (env var, project, then per-user) before falling back to the
+    // built-in default theme.
+    let config_path: Option<PathBuf> = matches
+        .get_one::<String>("config-path")
+        .map(PathBuf::from)
+        .or_else(discover_config_file);
+    let config_source = match &config_path {
+        Some(p) => markdown2pdf::config::ConfigSource::File(p.to_str().ok_or_else(|| {
+            AppError::PathError("config path is not valid UTF-8".to_string())
+        })?),
+        None => markdown2pdf::config::ConfigSource::Default,
+    };
+
     // `--print-effective-config` resolves the style and dumps it as
     // TOML; no markdown input required. Handled before any markdown
     // I/O so users can inspect the effective config in isolation.
     if matches.get_flag("print-effective-config") {
-        let config_source = match matches.get_one::<String>("config-path") {
-            Some(p) => markdown2pdf::config::ConfigSource::File(p.as_str()),
-            None => markdown2pdf::config::ConfigSource::Default,
-        };
         let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
         let style = markdown2pdf::config::load_config_strict_with_overrides(
             config_source,
@@ -266,10 +306,6 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // `[defaults].fallback_fonts` configured — without that, the
     // Unicode-without-font warning fires even when fallbacks fully
     // cover the document.
-    let config_source = match matches.get_one::<String>("config-path") {
-        Some(p) => markdown2pdf::config::ConfigSource::File(p.as_str()),
-        None => markdown2pdf::config::ConfigSource::Default,
-    };
     let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
     let resolved_style = markdown2pdf::config::load_config_strict_with_overrides(
         config_source,
@@ -350,6 +386,9 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Generate PDF
     if verbosity == Verbosity::Verbose {
         eprintln!("📄 Generating PDF...");
+        if let Some(path) = &config_path {
+            eprintln!("   Config: {}", path.display());
+        }
         if let Some(cfg) = &font_config {
             if let Some(font) = &cfg.default_font {
                 eprintln!("   Font: {}", font);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -278,6 +278,27 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     )
     .map_err(|e| AppError::ConversionError(e.to_string()))?;
 
+    // With no font on the CLI, fall back to the fonts named in the
+    // resolved style ([defaults].font_family / [code_block]). This
+    // lets a config file select an embeddable system font without
+    // the caller also passing --default-font.
+    let font_config = font_config.or_else(|| {
+        let default_font = resolved_style.paragraph.font_family.clone();
+        let code_font = resolved_style.code_block.font_family.clone();
+        if default_font.is_none() && code_font.is_none() {
+            return None;
+        }
+        Some(markdown2pdf::fonts::FontConfig {
+            default_font,
+            code_font,
+            enable_subsetting: true,
+            default_font_source: None,
+            code_font_source: None,
+            fallback_fonts: Vec::new(),
+            fallback_font_sources: Vec::new(),
+        })
+    });
+
     // Run validation checks
     if verbosity != Verbosity::Quiet {
         let warnings = validation::validate_conversion(

--- a/src/lib/fonts.rs
+++ b/src/lib/fonts.rs
@@ -199,18 +199,34 @@ pub fn system_font_dirs() -> Vec<&'static str> {
     }
 }
 
-/// Search system font directories for a TTF/OTF file matching `name`.
-/// Skips `.ttc` (TrueType Collection) files — most font parsers don't
-/// handle them.
+/// Search the platform's system font directories for a TTF/OTF file
+/// matching `name`. Skips `.ttc` (TrueType Collection) files — most
+/// font parsers don't handle them.
 pub fn find_system_font(name: &str) -> Option<PathBuf> {
+    find_system_font_in(name, &system_font_dirs())
+}
+
+/// `find_system_font` with the search directories injected, so the
+/// matching logic can be exercised against a controlled directory.
+fn find_system_font_in(name: &str, dirs: &[&str]) -> Option<PathBuf> {
     let name_lower = name.to_lowercase();
-    let patterns = [
+    let patterns: Vec<String> = [
         format!("{}.ttf", name),
         format!("{}.otf", name),
         format!("{}.ttf", name.replace(" MS", "")),
-    ];
+    ]
+    .iter()
+    .map(|p| p.to_lowercase())
+    .collect();
 
-    for dir in system_font_dirs() {
+    // An exact filename match always wins, but directory enumeration
+    // order is unspecified — a prefix like `Tahoma Bold.ttf` can be
+    // visited before the exact `Tahoma.ttf`. So scan every entry for
+    // an exact match first; only if none exists fall back to the
+    // shortest-named prefix match (regular faces have shorter names
+    // than their `X Bold` / `X Italic` siblings).
+    let mut prefix_match: Option<PathBuf> = None;
+    for dir in dirs {
         let dir_path = Path::new(dir);
         if !dir_path.exists() {
             continue;
@@ -226,19 +242,26 @@ pub fn find_system_font(name: &str) -> Option<PathBuf> {
                 continue;
             }
 
-            if patterns.iter().any(|p| file_lower == p.to_lowercase()) {
+            if patterns.iter().any(|p| file_lower == *p) {
                 return Some(entry.path());
             }
 
             if file_lower.starts_with(&name_lower)
                 && (file_lower.ends_with(".ttf") || file_lower.ends_with(".otf"))
             {
-                return Some(entry.path());
+                let shorter = prefix_match
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .map(|n| file_lower.len() < n.to_string_lossy().len())
+                    .unwrap_or(true);
+                if shorter {
+                    prefix_match = Some(entry.path());
+                }
             }
         }
     }
 
-    None
+    prefix_match
 }
 
 #[cfg(test)]
@@ -291,5 +314,52 @@ mod tests {
         // Don't assert anything platform-specific — just verify the
         // function returns successfully.
         let _ = system_font_dirs();
+    }
+
+    /// Builds a throwaway directory containing the named empty files
+    /// and runs `f` with its path. Cleans up afterwards.
+    fn with_font_dir(files: &[&str], f: impl FnOnce(&str)) {
+        let dir = std::env::temp_dir().join(format!(
+            "m2pdf_fonttest_{}_{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        for name in files {
+            std::fs::write(dir.join(name), b"x").unwrap();
+        }
+        f(dir.to_str().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn find_system_font_prefers_exact_over_prefix() {
+        // `Tahoma Bold.ttf` sorts before `Tahoma.ttf` and may be
+        // enumerated first — the exact match must still win, else the
+        // bold face gets used as the regular weight.
+        with_font_dir(&["Tahoma Bold.ttf", "Tahoma.ttf"], |dir| {
+            let found = find_system_font_in("Tahoma", &[dir]).unwrap();
+            assert_eq!(found.file_name().unwrap(), "Tahoma.ttf");
+        });
+    }
+
+    #[test]
+    fn find_system_font_prefix_fallback_picks_shortest() {
+        // No exact `Tahoma.ttf` — fall back to the shortest-named
+        // prefix match rather than whatever the OS lists first.
+        with_font_dir(&["Tahoma Italic.ttf", "Tahoma Bold.ttf"], |dir| {
+            let found = find_system_font_in("Tahoma", &[dir]).unwrap();
+            assert_eq!(found.file_name().unwrap(), "Tahoma Bold.ttf");
+        });
+    }
+
+    #[test]
+    fn find_system_font_skips_ttc() {
+        with_font_dir(&["Helvetica Neue.ttc"], |dir| {
+            assert!(find_system_font_in("Helvetica Neue", &[dir]).is_none());
+        });
     }
 }

--- a/src/lib/render/ir.rs
+++ b/src/lib/render/ir.rs
@@ -359,4 +359,22 @@ impl RunFlags {
         self.small = true;
         self
     }
+
+    /// OR every flag with `other`. Folds a block-level base style
+    /// (e.g. a heading's bold weight) into per-run inline flags so
+    /// the block style isn't lost when a run carries its own flags.
+    pub fn or(self, other: Self) -> Self {
+        Self {
+            bold: self.bold || other.bold,
+            italic: self.italic || other.italic,
+            monospace: self.monospace || other.monospace,
+            strikethrough: self.strikethrough || other.strikethrough,
+            underline: self.underline || other.underline,
+            highlight: self.highlight || other.highlight,
+            superscript: self.superscript || other.superscript,
+            subscript: self.subscript || other.subscript,
+            small_caps: self.small_caps || other.small_caps,
+            small: self.small || other.small,
+        }
+    }
 }

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2113,8 +2113,6 @@ impl<'a> Engine<'a> {
     }
 
     fn render_list(&mut self, entries: &[ListEntry]) {
-        const BULLET_GAP_MM: f32 = 2.0;
-        let bullet_gap_pt = mm_to_pt(BULLET_GAP_MM);
         let saved_left = self.indent_left_pt;
 
         // CommonMark §5.3: the whole list is loose if any item is loose.
@@ -2230,7 +2228,7 @@ impl<'a> Engine<'a> {
                 }
             }
 
-            self.indent_left_pt = (saved_left + bullet_width + bullet_gap_pt)
+            self.indent_left_pt = (saved_left + bullet_width + list_style.bullet_gap_pt)
                 .min(self.indent_right_pt - 10.0);
 
             self.write_wrapped_runs(
@@ -2521,7 +2519,7 @@ impl<'a> Engine<'a> {
         runs: &[InlineRun],
         font_size: f32,
         line_height_mult: f32,
-        _base_flags: RunFlags,
+        base_flags: RunFlags,
         color: Option<Color>,
     ) {
         if runs.is_empty() {
@@ -2529,6 +2527,23 @@ impl<'a> Engine<'a> {
         }
         let size_pt = font_size;
         let line_height_pt = size_pt * line_height_mult.max(0.5);
+
+        // Fold the block-level base style (e.g. a heading's bold
+        // weight) into every run so it isn't lost when a run carries
+        // its own inline flags. A default `base_flags` is a no-op.
+        let merged_runs;
+        let runs: &[InlineRun] = if base_flags == RunFlags::default() {
+            runs
+        } else {
+            merged_runs = runs
+                .iter()
+                .map(|r| InlineRun {
+                    flags: r.flags.or(base_flags),
+                    ..r.clone()
+                })
+                .collect::<Vec<_>>();
+            &merged_runs
+        };
 
         // Split runs into a flat sequence of (word, flags) pairs.
         // Whitespace is the only break opportunity in this phase.

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2807,7 +2807,7 @@ impl<'a> Engine<'a> {
                     }
                     // Restore the text fill colour if this is a link
                     // (link colour) vs body (block colour).
-                    if seg.flags.underline {
+                    if seg.link.is_some() {
                         if let Some(lc) = link_color.clone() {
                             self.page_ops.push(Op::SetFillColor { col: lc });
                         }
@@ -2826,6 +2826,9 @@ impl<'a> Engine<'a> {
                 // Buffer decorations and link rects until the line is
                 // finished — they need a closed text section to draw
                 // paths on top.
+                // A link is underlined only when `[link].underline`
+                // is set; `<u>` text always is.
+                let link_underline = seg.link.is_some() && self.style.link.underline;
                 if seg.flags.underline || seg.flags.strikethrough || seg.link.is_some() {
                     let decoration_y_pt = if seg.flags.strikethrough {
                         baseline_y_pt - size_pt * 0.30
@@ -2835,7 +2838,7 @@ impl<'a> Engine<'a> {
                     self.pending_decorations.push(PendingDecoration {
                         kind: if seg.flags.strikethrough {
                             DecorationKind::Strike
-                        } else if seg.flags.underline {
+                        } else if seg.flags.underline || link_underline {
                             DecorationKind::Underline
                         } else {
                             DecorationKind::None

--- a/src/lib/render/lower.rs
+++ b/src/lib/render/lower.rs
@@ -906,14 +906,13 @@ fn flatten_one(
             ));
         }
         Token::Link { content, url, .. } => {
-            // The link styling (underline + color) is applied at the
-            // layout pass — here we just propagate the URL and mark
-            // the run with underline so the visual decoration is
-            // ready before the annotation is drawn.
+            // Link styling (underline + colour) is applied at the
+            // layout pass from the `[link]` config — the run only
+            // carries the URL. The underline flag is *not* forced
+            // here, so `[link].underline = false` is honoured.
             let url_str = url.as_str();
-            let nested = flags.with_underline();
             for t in content {
-                flatten_one(t, nested, Some(url_str), out, footnotes);
+                flatten_one(t, flags, Some(url_str), out, footnotes);
             }
         }
         Token::FootnoteReference(label) => {

--- a/src/lib/render/mod.rs
+++ b/src/lib/render/mod.rs
@@ -127,7 +127,20 @@ pub fn render_to_bytes(
     };
 
     let blocks = lower::lower(&tokens);
-    let usage = ir::VariantUsage::analyze(&blocks);
+    let mut usage = ir::VariantUsage::analyze(&blocks);
+    // Headings and blockquotes get their weight / slant from the
+    // theme, not from per-run flags, so the IR walk above can't see
+    // them. Without this, an external font would skip loading the
+    // bold (or italic) face and these blocks would render regular.
+    for block_style in style.headings.iter().chain([&style.blockquote]) {
+        if block_style.is_bold() && block_style.is_italic() {
+            usage.body_bold_italic = true;
+        } else if block_style.is_bold() {
+            usage.body_bold = true;
+        } else if block_style.is_italic() {
+            usage.body_italic = true;
+        }
+    }
     let font_set = font::FontSet::load_with_style_fallbacks(
         font_config,
         &style.fallback_fonts,

--- a/src/lib/styling/merge.rs
+++ b/src/lib/styling/merge.rs
@@ -188,6 +188,7 @@ fn merge_list_style(base: ListStyleConfig, overlay: ListStyleConfig) -> ListStyl
         indent_per_level_pt: overlay.indent_per_level_pt.or(base.indent_per_level_pt),
         item_spacing_tight_pt: overlay.item_spacing_tight_pt.or(base.item_spacing_tight_pt),
         item_spacing_loose_pt: overlay.item_spacing_loose_pt.or(base.item_spacing_loose_pt),
+        bullet_gap_pt: overlay.bullet_gap_pt.or(base.bullet_gap_pt),
     }
 }
 
@@ -624,6 +625,10 @@ fn lower_list(
             .item_spacing_loose_pt
             .or(common.item_spacing_loose_pt)
             .unwrap_or(2.0),
+        bullet_gap_pt: raw
+            .bullet_gap_pt
+            .or(common.bullet_gap_pt)
+            .unwrap_or(5.67),
     })
 }
 

--- a/src/lib/styling/resolved.rs
+++ b/src/lib/styling/resolved.rs
@@ -97,6 +97,7 @@ pub struct ResolvedList {
     pub indent_per_level_pt: f32,
     pub item_spacing_tight_pt: f32,
     pub item_spacing_loose_pt: f32,
+    pub bullet_gap_pt: f32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/lib/styling/schema.rs
+++ b/src/lib/styling/schema.rs
@@ -182,6 +182,8 @@ pub struct ListStyleConfig {
     pub item_spacing_tight_pt: Option<f32>,
     /// Spacing between items in a loose list (blank line between items).
     pub item_spacing_loose_pt: Option<f32>,
+    /// Horizontal gap between the bullet/number and the item text.
+    pub bullet_gap_pt: Option<f32>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]

--- a/src/lib/styling/themes/default.toml
+++ b/src/lib/styling/themes/default.toml
@@ -130,6 +130,7 @@ margin_after_pt = 0.5
 indent_per_level_pt = 17.0  # ~6 mm
 item_spacing_tight_pt = 0.5
 item_spacing_loose_pt = 6.0
+bullet_gap_pt = 5.67  # ~2 mm gap between bullet and item text
 
 [list.unordered]
 bullet = "•"


### PR DESCRIPTION
**Font weight fixes.** System-font lookup could return a bold face
(e.g. `Tahoma Bold.ttf`) as the regular weight, rendering the whole
document heavy; an exact filename match now wins. Heading bold, which
comes from the style block rather than run flags, is now applied, and
the bold/italic faces it needs are embedded for external fonts.

**Config-driven body font.** `[defaults].font_family` now selects the
font that is loaded and embedded, not just `--default-font`.

**Configurable list bullet gap.** New `bullet_gap_pt` on
`[list.common]` sets the gap between a bullet and its text; defaults
to the previous `5.67` pt.

**Config file discovery.** With no `-c` flag, the CLI now finds a
config automatically — `MARKDOWN2PDF_CONFIG`, then `./markdown2pdf.toml`,
then `~/.config/markdown2pdf/config.toml` — before the default theme.

**Link underline honours config.** `[link].underline = false` now
suppresses the link underline; it was previously forced on regardless
of the configured style.