### PR TITLE
bump/1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,28 +37,30 @@ through the same transliteration the emit path uses, so the two
 agree exactly. Documents with no transliterated characters, and any
 document rendered with a Unicode font, are unaffected.
 
-**Font weight fixes.** System-font lookup could return a bold face
-(e.g. `Tahoma Bold.ttf`) as the regular weight, rendering the whole
-document heavy; an exact filename match now wins. Heading bold, which
-comes from the style block rather than run flags, is now applied, and
-the bold/italic faces it needs are embedded for external fonts.
-
-**Config-driven body font.** `[defaults].font_family` now selects the
-font that is loaded and embedded, not just `--default-font`.
-
-**Configurable list bullet gap.** New `bullet_gap_pt` on
-`[list.common]` sets the gap between a bullet and its text; defaults
-to the previous `5.67` pt.
-
 **Config file discovery.** With no `-c` flag, the CLI now finds a
 config automatically — `MARKDOWN2PDF_CONFIG`, then `./markdown2pdf.toml`,
 then `~/.config/markdown2pdf/config.toml` — before the default theme.
 
-**Link underline honours config.** `[link].underline = false` now
-suppresses the link underline; it was previously forced on regardless
-of the configured style.
+**Style-config fidelity.** A class of style fields the renderer was
+silently dropping is now honoured end-to-end. Body font: system-font
+lookup returning a bold face (e.g. `Tahoma Bold.ttf`) as the regular
+weight is fixed (exact filename wins), `[defaults].font_family`
+actually loads and embeds, heading bold from the style block is
+applied with its bold/italic faces embedded, and `[link].underline =
+false` suppresses the link underline. Per-block: `letter_spacing_pt`,
+`indent_pt`, `underline` / `strikethrough` / `text_align`, table
+`cell_padding` and `alternating_row_background`. Inline: every
+`code_inline` and `[mark]` field including `font_family` and
+`padding`. Layout: list `indent_per_level_pt` (plus a new
+`bullet_gap_pt` knob on `[list.common]`, defaulting to the previous
+`5.67` pt), image caption styling, title-page cover image, admonition
+body inheritance — nested lists inside a blockquote / admonition now
+adopt the container's typography. Center- and right-aligned
+paragraphs no longer collapse their wrapped lines onto line one.
+Multi-column page layout (`page.columns`) is the only audited field
+still deferred — [#102](https://github.com/theiskaa/markdown2pdf/issues/102).
 
-Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81) and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
+Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81), [#97](https://github.com/theiskaa/markdown2pdf/issues/97), and [#100](https://github.com/theiskaa/markdown2pdf/issues/100).
 
 ## [1.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ font that is loaded and embedded, not just `--default-font`.
 `[list.common]` sets the gap between a bullet and its text; defaults
 to the previous `5.67` pt.
 
+**Config file discovery.** With no `-c` flag, the CLI now finds a
+config automatically — `MARKDOWN2PDF_CONFIG`, then `./markdown2pdf.toml`,
+then `~/.config/markdown2pdf/config.toml` — before the default theme.
+
+**Link underline honours config.** `[link].underline = false` now
+suppresses the link underline; it was previously forced on regardless
+of the configured style.
+
 Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81) and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
 
 ## [1.3.0] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Each release section below is what ships as the GitHub Release notes.
 
+## [1.4.0] - 2026-05-21
+
+One addition: a font fallback chain so codepoints the primary font
+can't cover are routed to the first configured font that *can*. CJK,
+Arabic, Hebrew, math symbols, and emoji in an otherwise Latin
+document now render as real glyphs instead of `?` boxes. Purely
+additive — documents that don't configure fallbacks render byte-for-
+byte the same as on 1.3.0.
+
+**Fallback font chain.** A new `fallback_fonts` list on `[defaults]`
+in the TOML config (and `FontConfig::with_fallback_fonts(...)` for
+programmatic callers) takes an ordered list of font names. At render
+time each codepoint is matched against the primary first, then each
+fallback in declaration order; the first font that has a real glyph
+emits it. A codepoint covered by nothing in the chain degrades
+visibly (a `?` with the built-in primary, a missing-glyph box with an
+external Unicode primary) rather than failing the render. Names
+resolve the same way as `font_family`: built-in aliases, system font
+names, or paths to `.ttf` / `.otf` files; a font that can't be
+located logs a warning and is skipped. Wrapping and emission stay
+consistent across font boundaries, so mixed-script paragraphs don't
+overlap or break early.
+
+Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81).
+
 ## [1.3.0] - 2026-05-20
 
 Three additions: merged GFM table cells, inline HTML anchors and
@@ -418,6 +443,7 @@ Initial release: a Markdown lexer and a `genpdfi`-backed PDF
 converter with basic styling, configuration via `mdprc`, code blocks,
 emphasis, links, and nested tokens.
 
+[1.4.0]: https://github.com/theiskaa/markdown2pdf/releases/tag/v1.4.0
 [1.3.0]: https://github.com/theiskaa/markdown2pdf/releases/tag/v1.3.0
 [1.2.0]: https://github.com/theiskaa/markdown2pdf/releases/tag/v1.2.0
 [1.1.0]: https://github.com/theiskaa/markdown2pdf/releases/tag/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,6 @@ Each release section below is what ships as the GitHub Release notes.
 
 ## [1.4.0] - 2026-05-21
 
-One addition: a font fallback chain so codepoints the primary font
-can't cover are routed to the first configured font that *can*. CJK,
-Arabic, Hebrew, math symbols, and emoji in an otherwise Latin
-document now render as real glyphs instead of `?` boxes. Purely
-additive — documents that don't configure fallbacks render byte-for-
-byte the same as on 1.3.0.
-
 **Fallback font chain.** A new `fallback_fonts` list on `[defaults]`
 in the TOML config (and `FontConfig::with_fallback_fonts(...)` for
 programmatic callers) takes an ordered list of font names. At render
@@ -29,7 +22,23 @@ located logs a warning and is skipped. Wrapping and emission stay
 consistent across font boundaries, so mixed-script paragraphs don't
 overlap or break early.
 
-Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81).
+**Built-in measurement matches emission.** When no Unicode font is
+configured, the renderer transliterates non-ASCII punctuation to
+ASCII before emission (`•` → `*`, `—` → `--`, `…` → `...`, `(c)`,
+`(R)`, `(TM)`, smart quotes, NBSP). Line measurement, however, priced
+those source codepoints at the font's average glyph width, so the
+measured advance disagreed with what was actually drawn. The layout
+cursor drifted ahead of the PDF text matrix by the difference on
+every transliterated character, and the error compounded along the
+line — decorations and link hit-rectangles ended up beside their
+text rather than under it, most visibly on a line of several links
+separated by `•` or `—`. Measurement now routes every codepoint
+through the same transliteration the emit path uses, so the two
+agree exactly. Documents with no transliterated characters, and any
+document rendered with a Unicode font, are unaffected.
+
+Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81)
+and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
 
 ## [1.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,20 @@ through the same transliteration the emit path uses, so the two
 agree exactly. Documents with no transliterated characters, and any
 document rendered with a Unicode font, are unaffected.
 
-Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81)
-and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
+**Font weight fixes.** System-font lookup could return a bold face
+(e.g. `Tahoma Bold.ttf`) as the regular weight, rendering the whole
+document heavy; an exact filename match now wins. Heading bold, which
+comes from the style block rather than run flags, is now applied, and
+the bold/italic faces it needs are embedded for external fonts.
+
+**Config-driven body font.** `[defaults].font_family` now selects the
+font that is loaded and embedded, not just `--default-font`.
+
+**Configurable list bullet gap.** New `bullet_gap_pt` on
+`[list.common]` sets the gap between a bullet and its text; defaults
+to the previous `5.67` pt.
+
+Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81) and [#97](https://github.com/theiskaa/markdown2pdf/issues/97).
 
 ## [1.3.0] - 2026-05-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markdown2pdf"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "clap",
  "hyphenation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown2pdf"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Ismael Sh <me@theiskaa.com>"]

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Or, in `Cargo.toml`:
 
 ```toml
 # Minimal — local files only, no network, no SVG
-markdown2pdf = "1.3.0"
+markdown2pdf = "1.4.0"
 
 # Or with URL fetching + SVG rasterization
-markdown2pdf = { version = "1.3.0", features = ["fetch", "svg"] }
+markdown2pdf = { version = "1.4.0", features = ["fetch", "svg"] }
 ```
 
 See [docs/library.md](docs/library.md) for the programmatic API.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,8 @@ A configuration file is supplied with `-c`/`--config-path` and is parsed against
 markdown2pdf -p input.md -c brand.toml -o out.pdf
 ```
 
+When `-c` is omitted the binary looks for a configuration file automatically, in this order: the path in the `MARKDOWN2PDF_CONFIG` environment variable, then `markdown2pdf.toml` in the current directory (per-project), then `markdown2pdf/config.toml` under the user config directory (`$XDG_CONFIG_HOME`, else `~/.config`, else `%APPDATA%`). The first file that exists is used; if none is found the bundled `default` theme applies. An explicit `-c` always wins over discovery. A discovered path is reported under `--verbose`.
+
 Because the layering can be hard to reason about by inspection, `--print-effective-config` resolves the theme, the configuration file, and every override into the final style and prints it as TOML, then exits. It requires no input document and is the authoritative way to answer "what styling will actually be applied":
 
 ```sh

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -122,6 +122,7 @@ margin_after_pt = 0.5
 indent_per_level_pt = 17.0
 item_spacing_tight_pt = 0.5
 item_spacing_loose_pt = 2.0
+bullet_gap_pt = 5.67          # gap between the bullet/number and the text
 
 [list.unordered]
 bullet = "•"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -38,6 +38,13 @@ padding = 0.0              # scalar (all sides), [v, h], [t, r, b, l], or { top,
 margin_before_pt = 0.0
 margin_after_pt = 0.0
 indent_pt = 0.0
+# Ordered list of fallback fonts. Codepoints the primary body / code
+# font does not cover (CJK, Arabic, Hebrew, math symbols, emoji) are
+# looked up in each entry in turn; the first font with a glyph wins.
+# Names are resolved like `font_family`: built-ins, system font names,
+# or paths to a `.ttf` / `.otf` on disk. Leave empty (or omit) to keep
+# the previous behavior of rendering uncovered codepoints as `?`.
+# fallback_fonts = ["Noto Sans CJK SC", "Noto Sans Arabic", "Symbola"]
 
 
 [paragraph]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,18 @@ indent_pt = 0.0
 fallback_fonts = ["Noto Sans CJK SC", "Noto Sans Arabic", "Symbola"]
 ```
 
+### Body font
+
+`font_family` in `[defaults]` selects the font that is loaded and
+embedded — a built-in alias (`Helvetica`, `Times`, `Courier`), a system
+font name, or a path to a `.ttf` / `.otf` file. A built-in alias uses a
+PDF base-14 font (no embedding; non-ASCII glyphs transliterate to
+ASCII). Any other name is resolved against the system font directories
+and embedded, which is required for Unicode glyphs such as `•`.
+
+The `--default-font` CLI flag overrides this; when it is omitted the
+config's `font_family` is used.
+
 ### Fallback fonts
 
 `fallback_fonts` is an ordered list of font names consulted when the
@@ -235,6 +247,7 @@ margin_after_pt = 0.5
 indent_per_level_pt = 17.0
 item_spacing_tight_pt = 0.5  # CommonMark "tight" list (no blank lines)
 item_spacing_loose_pt = 2.0  # CommonMark "loose" list (any blank line)
+bullet_gap_pt = 5.67         # horizontal gap between the bullet/number and the item text
 
 [list.unordered]
 bullet = "•"   # any glyph

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,13 @@ markdown2pdf -p input.md -c my-config.toml -o out.pdf
 Every field is optional. `theme = "github"` (or any other preset)
 inherits a known-good baseline; you override only what you care about.
 
+To make a config the default without passing `-c` every time, place
+it where the binary discovers it automatically: `markdown2pdf.toml`
+in the project directory, or `markdown2pdf/config.toml` under your
+user config directory (`~/.config/markdown2pdf/config.toml` on
+macOS/Linux). The `MARKDOWN2PDF_CONFIG` environment variable also
+points at one. See [cli.md](cli.md) for the full lookup order.
+
 Any field below can also be overridden per-run from the command
 line (winning over the config file and `--theme`) — see
 [cli.md](cli.md#config-overrides) for `--title` / `--font-size` /

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,27 @@ padding = 0.0
 margin_before_pt = 0.0
 margin_after_pt = 0.0
 indent_pt = 0.0
+fallback_fonts = ["Noto Sans CJK SC", "Noto Sans Arabic", "Symbola"]
+```
+
+### Fallback fonts
+
+`fallback_fonts` is an ordered list of font names consulted when the
+primary body / code font lacks a glyph for a codepoint. Mixed-script
+documents (Latin + CJK, Arabic, Hebrew, math symbols, emoji) render
+each codepoint in the first configured font that covers it; characters
+unmatched by every font degrade to `?` rather than panicking.
+
+Names resolve the same way as `font_family` — built-in aliases, system
+font names, or paths to `.ttf` / `.otf` files. The field is only read
+from `[defaults]`; per-block tables ignore it.
+
+Programmatic callers can set the same list on `FontConfig`:
+
+```rust
+let cfg = FontConfig::new()
+    .with_default_font("Helvetica")
+    .with_fallback_fonts(["Noto Sans CJK SC", "Symbola"]);
 ```
 
 Colors accept hex strings (`"#RRGGBB"`, `"#RGB"`), structs

--- a/docs/library.md
+++ b/docs/library.md
@@ -5,10 +5,10 @@ The crate exposes the same conversion pipeline the binary uses, so any styling a
 Add the crate with Cargo. The default build has no network or SVG support; the optional `fetch` feature enables fetching remote images over a pure-Rust TLS stack, and the optional `svg` feature enables rasterizing SVG images:
 
 ```toml
-markdown2pdf = "1.3.0"
+markdown2pdf = "1.4.0"
 
 # with URL fetching + SVG rasterization
-markdown2pdf = { version = "1.3.0", features = ["fetch", "svg"] }
+markdown2pdf = { version = "1.4.0", features = ["fetch", "svg"] }
 ```
 
 ## Entry points

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -255,15 +255,37 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
             enable_subsetting: true,
             default_font_source: None,
             code_font_source: None,
+            fallback_fonts: Vec::new(),
+            fallback_font_sources: Vec::new(),
         })
     } else {
         None
     };
 
+    // Load the resolved style up front so validation can see any
+    // `[defaults].fallback_fonts` configured — without that, the
+    // Unicode-without-font warning fires even when fallbacks fully
+    // cover the document.
+    let config_source = match matches.get_one::<String>("config-path") {
+        Some(p) => markdown2pdf::config::ConfigSource::File(p.as_str()),
+        None => markdown2pdf::config::ConfigSource::Default,
+    };
+    let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
+    let resolved_style = markdown2pdf::config::load_config_strict_with_overrides(
+        config_source,
+        theme_override,
+        overrides.as_deref(),
+    )
+    .map_err(|e| AppError::ConversionError(e.to_string()))?;
+
     // Run validation checks
     if verbosity != Verbosity::Quiet {
-        let warnings =
-            validation::validate_conversion(&markdown, font_config.as_ref(), Some(output_path_str));
+        let warnings = validation::validate_conversion(
+            &markdown,
+            font_config.as_ref(),
+            &resolved_style.fallback_fonts,
+            Some(output_path_str),
+        );
 
         if !warnings.is_empty() {
             if verbosity == Verbosity::Verbose {
@@ -288,8 +310,12 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
             return Ok(());
         }
     } else if dry_run {
-        let warnings =
-            validation::validate_conversion(&markdown, font_config.as_ref(), Some(output_path_str));
+        let warnings = validation::validate_conversion(
+            &markdown,
+            font_config.as_ref(),
+            &resolved_style.fallback_fonts,
+            Some(output_path_str),
+        );
         if warnings.is_empty() {
             return Ok(());
         } else {
@@ -309,18 +335,6 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
             }
         }
     }
-
-    let config_source = match matches.get_one::<String>("config-path") {
-        Some(p) => markdown2pdf::config::ConfigSource::File(p.as_str()),
-        None => markdown2pdf::config::ConfigSource::Default,
-    };
-    let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
-    let resolved_style = markdown2pdf::config::load_config_strict_with_overrides(
-        config_source,
-        theme_override,
-        overrides.as_deref(),
-    )
-    .map_err(|e| AppError::ConversionError(e.to_string()))?;
 
     markdown2pdf::parse_into_file_with_style(
         markdown,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -196,6 +196,35 @@ fn get_output_path(matches: &clap::ArgMatches) -> Result<PathBuf, AppError> {
         .unwrap_or_else(|| current_dir.join("output.pdf")))
 }
 
+/// Locate a config file when `-c` was not given, in precedence order:
+/// the `MARKDOWN2PDF_CONFIG` env var, `./markdown2pdf.toml` in the
+/// working directory, then the per-user config. Returns the first
+/// that exists; `None` falls back to the built-in default theme.
+fn discover_config_file() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("MARKDOWN2PDF_CONFIG") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let project = PathBuf::from("markdown2pdf.toml");
+    if project.is_file() {
+        return Some(project);
+    }
+    user_config_file().filter(|p| p.is_file())
+}
+
+/// `<config-dir>/markdown2pdf/config.toml`, where the config dir is
+/// `XDG_CONFIG_HOME`, else `~/.config`, else `%APPDATA%`.
+fn user_config_file() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .or_else(|| std::env::var_os("APPDATA").map(PathBuf::from))?;
+    Some(base.join("markdown2pdf").join("config.toml"))
+}
+
 fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Determine verbosity level
     let verbosity = if matches.get_flag("quiet") {
@@ -212,14 +241,25 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Per-parameter CLI overrides (highest priority in the cascade).
     let overrides = build_overrides(&matches)?;
 
+    // Pick the config file once, so `--print-effective-config` and a
+    // real render agree. An explicit -c wins; otherwise discover one
+    // (env var, project, then per-user) before falling back to the
+    // built-in default theme.
+    let config_path: Option<PathBuf> = matches
+        .get_one::<String>("config-path")
+        .map(PathBuf::from)
+        .or_else(discover_config_file);
+    let config_source = match &config_path {
+        Some(p) => markdown2pdf::config::ConfigSource::File(p.to_str().ok_or_else(|| {
+            AppError::PathError("config path is not valid UTF-8".to_string())
+        })?),
+        None => markdown2pdf::config::ConfigSource::Default,
+    };
+
     // `--print-effective-config` resolves the style and dumps it as
     // TOML; no markdown input required. Handled before any markdown
     // I/O so users can inspect the effective config in isolation.
     if matches.get_flag("print-effective-config") {
-        let config_source = match matches.get_one::<String>("config-path") {
-            Some(p) => markdown2pdf::config::ConfigSource::File(p.as_str()),
-            None => markdown2pdf::config::ConfigSource::Default,
-        };
         let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
         let style = markdown2pdf::config::load_config_strict_with_overrides(
             config_source,
@@ -266,10 +306,6 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // `[defaults].fallback_fonts` configured — without that, the
     // Unicode-without-font warning fires even when fallbacks fully
     // cover the document.
-    let config_source = match matches.get_one::<String>("config-path") {
-        Some(p) => markdown2pdf::config::ConfigSource::File(p.as_str()),
-        None => markdown2pdf::config::ConfigSource::Default,
-    };
     let theme_override = matches.get_one::<String>("theme").map(|s| s.as_str());
     let resolved_style = markdown2pdf::config::load_config_strict_with_overrides(
         config_source,
@@ -350,6 +386,9 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     // Generate PDF
     if verbosity == Verbosity::Verbose {
         eprintln!("📄 Generating PDF...");
+        if let Some(path) = &config_path {
+            eprintln!("   Config: {}", path.display());
+        }
         if let Some(cfg) = &font_config {
             if let Some(font) = &cfg.default_font {
                 eprintln!("   Font: {}", font);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -278,6 +278,27 @@ fn run(matches: clap::ArgMatches) -> Result<(), AppError> {
     )
     .map_err(|e| AppError::ConversionError(e.to_string()))?;
 
+    // With no font on the CLI, fall back to the fonts named in the
+    // resolved style ([defaults].font_family / [code_block]). This
+    // lets a config file select an embeddable system font without
+    // the caller also passing --default-font.
+    let font_config = font_config.or_else(|| {
+        let default_font = resolved_style.paragraph.font_family.clone();
+        let code_font = resolved_style.code_block.font_family.clone();
+        if default_font.is_none() && code_font.is_none() {
+            return None;
+        }
+        Some(markdown2pdf::fonts::FontConfig {
+            default_font,
+            code_font,
+            enable_subsetting: true,
+            default_font_source: None,
+            code_font_source: None,
+            fallback_fonts: Vec::new(),
+            fallback_font_sources: Vec::new(),
+        })
+    });
+
     // Run validation checks
     if verbosity != Verbosity::Quiet {
         let warnings = validation::validate_conversion(

--- a/src/lib/fonts.rs
+++ b/src/lib/fonts.rs
@@ -58,6 +58,16 @@ pub struct FontConfig {
     pub default_font_source: Option<FontSource>,
     /// Font source for code blocks. Takes priority over `code_font` if set.
     pub code_font_source: Option<FontSource>,
+    /// Ordered list of fallback font *names* (system / path / built-in
+    /// alias). Resolved the same way as `default_font` at render time.
+    /// Composed with `fallback_font_sources` (sources first, then names)
+    /// and with any `fallback_fonts` set on `[defaults]` in the TOML
+    /// config.
+    pub fallback_fonts: Vec<String>,
+    /// Ordered list of pre-resolved fallback font sources. Useful when
+    /// embedding fonts via `include_bytes!` or pointing at a known
+    /// path. Composed before `fallback_fonts`.
+    pub fallback_font_sources: Vec<FontSource>,
     /// Enable font subsetting for smaller PDFs.
     pub enable_subsetting: bool,
 }
@@ -70,6 +80,8 @@ impl FontConfig {
             code_font: None,
             default_font_source: None,
             code_font_source: None,
+            fallback_fonts: Vec::new(),
+            fallback_font_sources: Vec::new(),
             enable_subsetting: true,
         }
     }
@@ -101,6 +113,28 @@ impl FontConfig {
     /// Enable or disable font subsetting.
     pub fn with_subsetting(mut self, enabled: bool) -> Self {
         self.enable_subsetting = enabled;
+        self
+    }
+
+    /// Replace the fallback-font name list. See [`FontConfig::fallback_fonts`].
+    pub fn with_fallback_fonts<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.fallback_fonts = names.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Append one fallback name to the existing list.
+    pub fn add_fallback_font(mut self, name: impl Into<String>) -> Self {
+        self.fallback_fonts.push(name.into());
+        self
+    }
+
+    /// Append one pre-resolved fallback font source.
+    pub fn add_fallback_font_source(mut self, source: FontSource) -> Self {
+        self.fallback_font_sources.push(source);
         self
     }
 }

--- a/src/lib/fonts.rs
+++ b/src/lib/fonts.rs
@@ -317,16 +317,18 @@ mod tests {
     }
 
     /// Builds a throwaway directory containing the named empty files
-    /// and runs `f` with its path. Cleans up afterwards.
+    /// and runs `f` with its path. Cleans up afterwards. The directory
+    /// name is made unique with a process-wide atomic counter so the
+    /// parallel font tests can't collide on each other's files.
     fn with_font_dir(files: &[&str], f: impl FnOnce(&str)) {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static SEQ: AtomicU32 = AtomicU32::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "m2pdf_fonttest_{}_{:?}",
+            "m2pdf_fonttest_{}_{}",
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            SEQ.fetch_add(1, Ordering::Relaxed)
         ));
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         for name in files {
             std::fs::write(dir.join(name), b"x").unwrap();

--- a/src/lib/fonts.rs
+++ b/src/lib/fonts.rs
@@ -199,18 +199,34 @@ pub fn system_font_dirs() -> Vec<&'static str> {
     }
 }
 
-/// Search system font directories for a TTF/OTF file matching `name`.
-/// Skips `.ttc` (TrueType Collection) files — most font parsers don't
-/// handle them.
+/// Search the platform's system font directories for a TTF/OTF file
+/// matching `name`. Skips `.ttc` (TrueType Collection) files — most
+/// font parsers don't handle them.
 pub fn find_system_font(name: &str) -> Option<PathBuf> {
+    find_system_font_in(name, &system_font_dirs())
+}
+
+/// `find_system_font` with the search directories injected, so the
+/// matching logic can be exercised against a controlled directory.
+fn find_system_font_in(name: &str, dirs: &[&str]) -> Option<PathBuf> {
     let name_lower = name.to_lowercase();
-    let patterns = [
+    let patterns: Vec<String> = [
         format!("{}.ttf", name),
         format!("{}.otf", name),
         format!("{}.ttf", name.replace(" MS", "")),
-    ];
+    ]
+    .iter()
+    .map(|p| p.to_lowercase())
+    .collect();
 
-    for dir in system_font_dirs() {
+    // An exact filename match always wins, but directory enumeration
+    // order is unspecified — a prefix like `Tahoma Bold.ttf` can be
+    // visited before the exact `Tahoma.ttf`. So scan every entry for
+    // an exact match first; only if none exists fall back to the
+    // shortest-named prefix match (regular faces have shorter names
+    // than their `X Bold` / `X Italic` siblings).
+    let mut prefix_match: Option<PathBuf> = None;
+    for dir in dirs {
         let dir_path = Path::new(dir);
         if !dir_path.exists() {
             continue;
@@ -226,19 +242,26 @@ pub fn find_system_font(name: &str) -> Option<PathBuf> {
                 continue;
             }
 
-            if patterns.iter().any(|p| file_lower == p.to_lowercase()) {
+            if patterns.iter().any(|p| file_lower == *p) {
                 return Some(entry.path());
             }
 
             if file_lower.starts_with(&name_lower)
                 && (file_lower.ends_with(".ttf") || file_lower.ends_with(".otf"))
             {
-                return Some(entry.path());
+                let shorter = prefix_match
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .map(|n| file_lower.len() < n.to_string_lossy().len())
+                    .unwrap_or(true);
+                if shorter {
+                    prefix_match = Some(entry.path());
+                }
             }
         }
     }
 
-    None
+    prefix_match
 }
 
 #[cfg(test)]
@@ -291,5 +314,52 @@ mod tests {
         // Don't assert anything platform-specific — just verify the
         // function returns successfully.
         let _ = system_font_dirs();
+    }
+
+    /// Builds a throwaway directory containing the named empty files
+    /// and runs `f` with its path. Cleans up afterwards.
+    fn with_font_dir(files: &[&str], f: impl FnOnce(&str)) {
+        let dir = std::env::temp_dir().join(format!(
+            "m2pdf_fonttest_{}_{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        for name in files {
+            std::fs::write(dir.join(name), b"x").unwrap();
+        }
+        f(dir.to_str().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn find_system_font_prefers_exact_over_prefix() {
+        // `Tahoma Bold.ttf` sorts before `Tahoma.ttf` and may be
+        // enumerated first — the exact match must still win, else the
+        // bold face gets used as the regular weight.
+        with_font_dir(&["Tahoma Bold.ttf", "Tahoma.ttf"], |dir| {
+            let found = find_system_font_in("Tahoma", &[dir]).unwrap();
+            assert_eq!(found.file_name().unwrap(), "Tahoma.ttf");
+        });
+    }
+
+    #[test]
+    fn find_system_font_prefix_fallback_picks_shortest() {
+        // No exact `Tahoma.ttf` — fall back to the shortest-named
+        // prefix match rather than whatever the OS lists first.
+        with_font_dir(&["Tahoma Italic.ttf", "Tahoma Bold.ttf"], |dir| {
+            let found = find_system_font_in("Tahoma", &[dir]).unwrap();
+            assert_eq!(found.file_name().unwrap(), "Tahoma Bold.ttf");
+        });
+    }
+
+    #[test]
+    fn find_system_font_skips_ttc() {
+        with_font_dir(&["Helvetica Neue.ttc"], |dir| {
+            assert!(find_system_font_in("Helvetica Neue", &[dir]).is_none());
+        });
     }
 }

--- a/src/lib/render/font.rs
+++ b/src/lib/render/font.rs
@@ -268,6 +268,11 @@ pub struct FontSet {
     pub builtin: FontMetricsCache,
     pub external_body: ExternalFamily,
     pub external_code: ExternalFamily,
+    /// Inline-code / `<kbd>` family, separate from `external_code`
+    /// (which serves fenced code blocks). Loaded only when
+    /// `[code_inline].font_family` is configured; otherwise inline-code
+    /// runs fall through to `external_code`, then to builtin Courier.
+    pub external_code_inline: ExternalFamily,
     /// Ordered fallback fonts consulted when the primary body / code
     /// font does not cover a codepoint. Regular weight only — fallbacks
     /// are loaded once per family and reused for every flag combination.
@@ -380,10 +385,20 @@ impl FontSet {
             italic: usage.body_italic || usage.body_bold_italic,
             bold_italic: usage.body_bold_italic,
         };
+        // Inline-code variants count toward the regular code family
+        // too: when `[code_inline].font_family` isn't configured,
+        // inline-code runs fall back to `external_code` and still need
+        // its bold / italic faces.
         let code_variants = BodyVariantNeed {
-            bold: usage.mono_bold || usage.mono_bold_italic,
-            italic: usage.mono_italic || usage.mono_bold_italic,
-            bold_italic: usage.mono_bold_italic,
+            bold: usage.mono_bold
+                || usage.mono_bold_italic
+                || usage.inline_code_bold
+                || usage.inline_code_bold_italic,
+            italic: usage.mono_italic
+                || usage.mono_bold_italic
+                || usage.inline_code_italic
+                || usage.inline_code_bold_italic,
+            bold_italic: usage.mono_bold_italic || usage.inline_code_bold_italic,
         };
         let external_body = font_config
             .and_then(|c| load_external_family(default_source(c), used_codepoints, body_variants, doc))
@@ -408,22 +423,42 @@ impl FontSet {
             builtin,
             external_body,
             external_code,
+            external_code_inline: ExternalFamily::default(),
             fallbacks,
         }
     }
 
     /// Build the font set with an additional list of fallback sources
     /// (resolved from `[defaults].fallback_fonts` in the styling
-    /// config). Names are appended *after* anything declared on
-    /// `FontConfig` so programmatic config wins on order.
+    /// config) and an optional dedicated inline-code font family
+    /// (`[code_inline].font_family`). Fallback names are appended
+    /// *after* anything declared on `FontConfig` so programmatic
+    /// config wins on order. When `code_inline_name` is `None` the
+    /// inline-code family stays empty and inline-code runs fall
+    /// through to the regular code family.
     pub fn load_with_style_fallbacks(
         font_config: Option<&FontConfig>,
         style_fallback_names: &[String],
+        code_inline_name: Option<&str>,
         used_codepoints: &[char],
         usage: VariantUsage,
         doc: &mut PdfDocument,
     ) -> Self {
         let mut set = Self::load(font_config, used_codepoints, usage, doc);
+        if let Some(name) = code_inline_name {
+            let inline_variants = BodyVariantNeed {
+                bold: usage.inline_code_bold || usage.inline_code_bold_italic,
+                italic: usage.inline_code_italic || usage.inline_code_bold_italic,
+                bold_italic: usage.inline_code_bold_italic,
+            };
+            set.external_code_inline = load_external_family(
+                Some(name_to_external_source(name)),
+                used_codepoints,
+                inline_variants,
+                doc,
+            )
+            .unwrap_or_default();
+        }
         for name in style_fallback_names {
             let src = name_to_external_source(name);
             let Some((_, bytes)) = resolve_regular(src) else {
@@ -440,6 +475,14 @@ impl FontSet {
     /// *primary* font for that flag combination. Fallback selection
     /// happens per-codepoint inside [`FontSet::split_for_emit`].
     pub fn resolve(&self, flags: RunFlags) -> FontResolution<'_> {
+        if flags.inline_code {
+            if let Some(ext) = self.external_code_inline.pick(flags) {
+                return FontResolution::External {
+                    handle: PdfFontHandle::External(ext.font_id.clone()),
+                    font: ext,
+                };
+            }
+        }
         if flags.monospace {
             if let Some(ext) = self.external_code.pick(flags) {
                 return FontResolution::External {

--- a/src/lib/render/font.rs
+++ b/src/lib/render/font.rs
@@ -144,16 +144,28 @@ impl VariantMetrics {
     }
 
     /// Advance width of `text` at `font_size_pt`, in points.
+    ///
+    /// For each input char, sums the advances of the chars that the
+    /// built-in emit path will actually write (see
+    /// [`for_each_builtin_emit_char`]). Measuring the source codepoints
+    /// directly would charge a `fallback_width` for things like `•`
+    /// while the emit path writes `*` — the resulting drift between
+    /// measured and rendered x positions misplaces underlines, link
+    /// rects, and wrap break points on lines containing transliterated
+    /// characters.
     pub fn measure(&self, text: &str, font_size_pt: f32) -> f32 {
         let mut unscaled: u64 = 0;
         for c in text.chars() {
-            let w = if (c as u32) < 256 {
-                self.unscaled_widths[c as usize]
-            } else {
-                0
-            };
-            let w = if w == 0 { self.fallback_width } else { w };
-            unscaled += w as u64;
+            for_each_builtin_emit_char(c, |emitted| {
+                let idx = emitted as u32 as usize;
+                let w = if idx < 256 {
+                    self.unscaled_widths[idx]
+                } else {
+                    0
+                };
+                let w = if w == 0 { self.fallback_width } else { w };
+                unscaled += w as u64;
+            });
         }
         unscaled as f32 * font_size_pt / self.units_per_em as f32
     }
@@ -808,6 +820,51 @@ fn find_variant_path(anchor: &std::path::Path, variant_names: &[&str]) -> Option
     None
 }
 
+/// Invoke `f` once per char that the built-in (Helvetica/Courier)
+/// emit path will actually write for `c`. ASCII passes through; a
+/// curated set of Win-1252 punctuation transliterates to ASCII (often
+/// expanding one source char into several, e.g. `—` → `--`); anything
+/// else becomes `?`. The shared source of truth for both measurement
+/// (`VariantMetrics::measure`) and emission (`to_win1252` in layout) —
+/// drift between the two misplaces underlines, link rects, and line
+/// breaks on lines containing transliterated characters.
+pub fn for_each_builtin_emit_char(c: char, mut f: impl FnMut(char)) {
+    match c as u32 {
+        0x00..=0x7F => f(c),
+        0x2014 => {
+            f('-');
+            f('-');
+        }
+        0x2013 => f('-'),
+        0x2022 => f('*'),
+        0x2018 | 0x2019 => f('\''),
+        0x201C | 0x201D => f('"'),
+        0x2026 => {
+            f('.');
+            f('.');
+            f('.');
+        }
+        0x00A0 => f(' '),
+        0x00A9 => {
+            f('(');
+            f('c');
+            f(')');
+        }
+        0x00AE => {
+            f('(');
+            f('R');
+            f(')');
+        }
+        0x2122 => {
+            f('(');
+            f('T');
+            f('M');
+            f(')');
+        }
+        _ => f('?'),
+    }
+}
+
 /// Code points the renderer might synthesize at layout time even if
 /// they never appear in the source document — bullet glyphs,
 /// task-list brackets, ordered-list digits, etc. Including them in
@@ -1087,6 +1144,55 @@ mod tests {
                 summed
             );
         }
+    }
+
+    #[test]
+    fn builtin_measure_matches_transliterated_emit() {
+        // `to_win1252` rewrites a curated set of Win-1252 punctuation
+        // to ASCII before emission (`•` → `*`, `—` → `--`, `…` → `...`,
+        // `(c)`, `(R)`, `(TM)`, etc.). `measure` must price each source
+        // char at the advance the emit path will actually write, or the
+        // layout cursor drifts away from the PDF text matrix and
+        // misplaces underlines / link rects.
+        let cache = FontMetricsCache::new();
+        let m = cache.for_variant(FontVariant::HelveticaRegular);
+        let pairs = [
+            ("\u{2022}", "*"),
+            ("\u{2014}", "--"),
+            ("\u{2013}", "-"),
+            ("\u{2026}", "..."),
+            ("\u{2018}", "'"),
+            ("\u{2019}", "'"),
+            ("\u{201C}", "\""),
+            ("\u{201D}", "\""),
+            ("\u{00A0}", " "),
+            ("\u{00A9}", "(c)"),
+            ("\u{00AE}", "(R)"),
+            ("\u{2122}", "(TM)"),
+            ("a \u{2022} b \u{2014} c \u{2026}", "a * b -- c ..."),
+        ];
+        for (src, emitted) in pairs {
+            let measured = m.measure(src, 12.0);
+            let actual = m.measure(emitted, 12.0);
+            assert!(
+                (measured - actual).abs() < 1e-3,
+                "measure({:?}) = {} but emit writes {:?} with width {}",
+                src,
+                measured,
+                emitted,
+                actual,
+            );
+        }
+        // Codepoints that aren't in the curated map should price as
+        // `?`, which is what `to_win1252` will actually emit for them.
+        let unknown = m.measure("\u{4E2D}", 12.0);
+        let q = m.measure("?", 12.0);
+        assert!(
+            (unknown - q).abs() < 1e-3,
+            "uncurated codepoint should price as '?': {} vs {}",
+            unknown,
+            q,
+        );
     }
 
     #[test]

--- a/src/lib/render/font.rs
+++ b/src/lib/render/font.rs
@@ -232,6 +232,15 @@ impl ExternalFont {
         }
         unscaled as f32 * font_size_pt / self.units_per_em as f32
     }
+
+    /// `true` if this font has a real glyph for `c` (i.e. the
+    /// codepoint was in the keep-set when the font was loaded *and*
+    /// the un-subsetted face exposed a non-`.notdef` glyph index for
+    /// it). Used to pick which font in a fallback chain emits a
+    /// given codepoint.
+    pub fn covers(&self, c: char) -> bool {
+        self.advance_by_codepoint.contains_key(&(c as u32))
+    }
 }
 
 /// The complete font set for one render call: built-ins always
@@ -247,6 +256,10 @@ pub struct FontSet {
     pub builtin: FontMetricsCache,
     pub external_body: ExternalFamily,
     pub external_code: ExternalFamily,
+    /// Ordered fallback fonts consulted when the primary body / code
+    /// font does not cover a codepoint. Regular weight only — fallbacks
+    /// are loaded once per family and reused for every flag combination.
+    pub fallbacks: Vec<ExternalFont>,
 }
 
 /// Up to four weight slots for an external font family.
@@ -303,6 +316,31 @@ pub enum FontResolution<'a> {
     },
 }
 
+/// One contiguous run of text destined for a single PDF font handle.
+/// Produced by [`FontSet::split_for_emit`]: the layout engine emits
+/// one `SetFont` + `ShowText` pair per chunk.
+#[derive(Debug, Clone)]
+pub struct EmitChunk {
+    pub handle: PdfFontHandle,
+    /// `true` iff `text` must pass through `to_win1252` before reaching
+    /// `Op::ShowText`. Only set for built-in chunks.
+    pub needs_transliteration: bool,
+    pub text: String,
+    /// Advance width of `text` at the size requested by the caller of
+    /// `split_for_emit`. Precomputed so the call site doesn't have to
+    /// re-walk the codepoints.
+    pub width_pt: f32,
+}
+
+/// Per-codepoint choice of which font slot emits it. Used internally
+/// by `split_for_emit` to group consecutive same-choice codepoints
+/// into chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FontPick {
+    Primary,
+    Fallback(usize),
+}
+
 impl FontSet {
     /// Build the font set for a render call.
     ///
@@ -312,6 +350,12 @@ impl FontSet {
     /// bold/italic/bold-italic faces that the document never asks
     /// for. Regular is always loaded; the optional weights are
     /// loaded only when `usage` flags them.
+    ///
+    /// `extra_fallbacks` is the list of fallback font sources
+    /// configured at the document level (`[defaults].fallback_fonts`
+    /// in TOML) combined with any sources/names on `FontConfig`. Each
+    /// is loaded in order, regular weight only; consumed by
+    /// [`FontSet::split_for_emit`] when the primary lacks a glyph.
     pub fn load(
         font_config: Option<&FontConfig>,
         used_codepoints: &[char],
@@ -347,14 +391,42 @@ impl FontSet {
         };
         let external_code = load_external_family(code_src, used_codepoints, code_variants, doc)
             .unwrap_or_default();
+        let fallbacks = load_fallbacks(font_config, used_codepoints, doc);
         Self {
             builtin,
             external_body,
             external_code,
+            fallbacks,
         }
     }
 
-    /// Resolve a [`RunFlags`] to a concrete font choice.
+    /// Build the font set with an additional list of fallback sources
+    /// (resolved from `[defaults].fallback_fonts` in the styling
+    /// config). Names are appended *after* anything declared on
+    /// `FontConfig` so programmatic config wins on order.
+    pub fn load_with_style_fallbacks(
+        font_config: Option<&FontConfig>,
+        style_fallback_names: &[String],
+        used_codepoints: &[char],
+        usage: VariantUsage,
+        doc: &mut PdfDocument,
+    ) -> Self {
+        let mut set = Self::load(font_config, used_codepoints, usage, doc);
+        for name in style_fallback_names {
+            let src = name_to_external_source(name);
+            let Some((_, bytes)) = resolve_regular(src) else {
+                continue;
+            };
+            if let Some(font) = parse_and_register(bytes, "fallback", used_codepoints, doc) {
+                set.fallbacks.push(font);
+            }
+        }
+        set
+    }
+
+    /// Resolve a [`RunFlags`] to a concrete font choice — the
+    /// *primary* font for that flag combination. Fallback selection
+    /// happens per-codepoint inside [`FontSet::split_for_emit`].
     pub fn resolve(&self, flags: RunFlags) -> FontResolution<'_> {
         if flags.monospace {
             if let Some(ext) = self.external_code.pick(flags) {
@@ -376,27 +448,184 @@ impl FontSet {
         }
     }
 
+    /// Total advance width of `text` at `size_pt`. Walks fallback
+    /// coverage so a mixed-script run measures correctly even when
+    /// different codepoints render in different fonts.
     pub fn measure(&self, flags: RunFlags, text: &str, size_pt: f32) -> f32 {
-        match self.resolve(flags) {
-            FontResolution::Builtin { metrics, .. } => metrics.measure(text, size_pt),
-            FontResolution::External { font, .. } => font.measure(text, size_pt),
+        if self.fallbacks.is_empty() {
+            return match self.resolve(flags) {
+                FontResolution::Builtin { metrics, .. } => metrics.measure(text, size_pt),
+                FontResolution::External { font, .. } => font.measure(text, size_pt),
+            };
         }
+        self.split_for_emit(flags, text, size_pt)
+            .iter()
+            .map(|c| c.width_pt)
+            .sum()
     }
 
-    pub fn handle(&self, flags: RunFlags) -> PdfFontHandle {
-        match self.resolve(flags) {
-            FontResolution::Builtin { handle, .. } | FontResolution::External { handle, .. } => {
-                handle
-            }
-        }
-    }
-
-    /// `true` if text emitted via this variant has to pass through
-    /// the `to_win1252` ASCII transliterator (because the built-in
-    /// font path can't survive non-ASCII bytes).
+    /// `true` if the *primary* font for `flags` is a built-in and
+    /// emitted text has to pass through `to_win1252`. Note: even when
+    /// this returns `true`, individual codepoints may still emit via
+    /// an external fallback — only the primary's policy is reported.
     pub fn needs_transliteration(&self, flags: RunFlags) -> bool {
         matches!(self.resolve(flags), FontResolution::Builtin { .. })
     }
+
+    /// Split `text` into the smallest sequence of single-font chunks
+    /// that the layout engine can emit one-after-another. Each chunk's
+    /// codepoints are all covered by the same font slot: the primary
+    /// for the run's flags, or one of the loaded fallbacks (the first
+    /// one whose face has a glyph for the codepoint).
+    ///
+    /// When the primary is a built-in (ASCII-only via WinAnsi
+    /// transliteration), every non-ASCII codepoint tries the fallback
+    /// chain. When the primary is an external Unicode font,
+    /// codepoints absent from its subset try the fallback chain.
+    /// Codepoints covered nowhere are emitted on the primary (where
+    /// the renderer will show `.notdef` boxes or transliterate to
+    /// `?`).
+    ///
+    /// Width is precomputed against `size_pt` so callers that need
+    /// both a width sum (for wrapping) and a per-chunk emission don't
+    /// pay the per-glyph scan twice.
+    pub fn split_for_emit(
+        &self,
+        flags: RunFlags,
+        text: &str,
+        size_pt: f32,
+    ) -> Vec<EmitChunk> {
+        if text.is_empty() {
+            return Vec::new();
+        }
+        let primary = self.resolve(flags);
+        // Fast path: no fallbacks configured. Everything emits via the
+        // primary as a single chunk. Identical behavior to the
+        // pre-fallback code path.
+        if self.fallbacks.is_empty() {
+            return vec![chunk_from_resolution(&primary, text.to_string(), size_pt)];
+        }
+        let mut chunks: Vec<EmitChunk> = Vec::new();
+        let mut buf = String::new();
+        let mut current: Option<FontPick> = None;
+        for c in text.chars() {
+            let pick = if primary_covers(&primary, c) {
+                FontPick::Primary
+            } else if let Some(idx) = self.fallbacks.iter().position(|f| f.covers(c)) {
+                FontPick::Fallback(idx)
+            } else {
+                // No font in the chain covers `c`. Emit via the primary
+                // — that path will either render `.notdef` (external) or
+                // transliterate to `?` (built-in). Either degradation is
+                // visible and non-panicking.
+                FontPick::Primary
+            };
+            match current {
+                Some(cur) if cur == pick => buf.push(c),
+                Some(cur) => {
+                    chunks.push(self.build_chunk(cur, std::mem::take(&mut buf), &primary, size_pt));
+                    buf.push(c);
+                    current = Some(pick);
+                }
+                None => {
+                    buf.push(c);
+                    current = Some(pick);
+                }
+            }
+        }
+        if let Some(cur) = current {
+            chunks.push(self.build_chunk(cur, buf, &primary, size_pt));
+        }
+        chunks
+    }
+
+    fn build_chunk(
+        &self,
+        pick: FontPick,
+        text: String,
+        primary: &FontResolution<'_>,
+        size_pt: f32,
+    ) -> EmitChunk {
+        match pick {
+            FontPick::Primary => chunk_from_resolution(primary, text, size_pt),
+            FontPick::Fallback(idx) => {
+                let font = &self.fallbacks[idx];
+                let width_pt = font.measure(&text, size_pt);
+                EmitChunk {
+                    handle: PdfFontHandle::External(font.font_id.clone()),
+                    needs_transliteration: false,
+                    text,
+                    width_pt,
+                }
+            }
+        }
+    }
+}
+
+/// `true` iff the *primary* font (already resolved for the run flags)
+/// has a glyph for `c`. For built-ins this is "ASCII or directly
+/// representable in WinAnsi"; for external faces it's a subset
+/// membership check.
+fn primary_covers(primary: &FontResolution<'_>, c: char) -> bool {
+    match primary {
+        FontResolution::External { font, .. } => font.covers(c),
+        FontResolution::Builtin { .. } => (c as u32) < 0x80,
+    }
+}
+
+fn chunk_from_resolution(
+    primary: &FontResolution<'_>,
+    text: String,
+    size_pt: f32,
+) -> EmitChunk {
+    match primary {
+        FontResolution::Builtin { handle, metrics } => {
+            let width_pt = metrics.measure(&text, size_pt);
+            EmitChunk {
+                handle: handle.clone(),
+                needs_transliteration: true,
+                text,
+                width_pt,
+            }
+        }
+        FontResolution::External { handle, font } => {
+            let width_pt = font.measure(&text, size_pt);
+            EmitChunk {
+                handle: handle.clone(),
+                needs_transliteration: false,
+                text,
+                width_pt,
+            }
+        }
+    }
+}
+
+/// Load every fallback font declared on `FontConfig`, in order. Each
+/// is parsed as a regular-weight family (no bold / italic discovery —
+/// fallbacks reuse the regular glyphs for every flag combination).
+/// Failures are logged and skipped, never propagated; a missing
+/// fallback simply means uncovered codepoints stay uncovered.
+fn load_fallbacks(
+    font_config: Option<&FontConfig>,
+    used_codepoints: &[char],
+    doc: &mut PdfDocument,
+) -> Vec<ExternalFont> {
+    let mut out = Vec::new();
+    let Some(cfg) = font_config else {
+        return out;
+    };
+    let mut sources: Vec<FontSource> = Vec::new();
+    sources.extend(cfg.fallback_font_sources.iter().cloned());
+    sources.extend(cfg.fallback_fonts.iter().map(|n| name_to_external_source(n)));
+    for src in sources {
+        let Some((_, bytes)) = resolve_regular(src) else {
+            continue;
+        };
+        if let Some(font) = parse_and_register(bytes, "fallback", used_codepoints, doc) {
+            out.push(font);
+        }
+    }
+    out
 }
 
 fn default_source(c: &FontConfig) -> Option<FontSource> {
@@ -806,6 +1035,83 @@ mod tests {
         // On Linux containers without any monospace font installed,
         // None is the correct answer (graceful degradation to the
         // built-in Courier path).
+    }
+
+    #[test]
+    fn split_with_no_fallbacks_returns_single_chunk() {
+        // No font_config + no fallbacks = built-in Helvetica path. The
+        // whole input becomes a single chunk with the transliteration
+        // policy of the built-in path — matching the pre-fallback
+        // behavior.
+        let mut doc = PdfDocument::new("test");
+        let set = FontSet::load(None, &[], VariantUsage::default(), &mut doc);
+        let chunks = set.split_for_emit(RunFlags::default(), "Hello", 12.0);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].text, "Hello");
+        assert!(chunks[0].needs_transliteration);
+        assert!(chunks[0].width_pt > 0.0);
+    }
+
+    #[test]
+    fn split_empty_text_returns_empty() {
+        let mut doc = PdfDocument::new("test");
+        let set = FontSet::load(None, &[], VariantUsage::default(), &mut doc);
+        let chunks = set.split_for_emit(RunFlags::default(), "", 12.0);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn measure_equals_sum_of_per_chunk_widths() {
+        // The wrapping path calls `measure(flags, text, size)` and the
+        // emit path iterates `split_for_emit(flags, text, size)`. The
+        // sum of per-chunk widths must equal `measure` exactly, or
+        // wrap will under-/over-estimate where the glyphs actually
+        // land. This test pins the invariant for the no-fallback fast
+        // path (the only one we can construct without an external
+        // font file in unit tests).
+        let mut doc = PdfDocument::new("test");
+        let set = FontSet::load(None, &[], VariantUsage::default(), &mut doc);
+        let cases = ["", "Hello", "Hello world", "ABCDE 12345 !?.,"];
+        for text in cases {
+            let direct = set.measure(RunFlags::default(), text, 10.0);
+            let summed: f32 = set
+                .split_for_emit(RunFlags::default(), text, 10.0)
+                .iter()
+                .map(|c| c.width_pt)
+                .sum();
+            assert!(
+                (direct - summed).abs() < 1e-3,
+                "measure({:?}) {} != sum-of-chunks {}",
+                text,
+                direct,
+                summed
+            );
+        }
+    }
+
+    #[test]
+    fn missing_fallback_source_does_not_panic() {
+        // A configured fallback that can't be located on disk should
+        // simply not load — the renderer must still emit text through
+        // the primary font (degraded for uncovered codepoints, never
+        // a panic). Verifies graceful no-op on bad config.
+        let cfg = FontConfig {
+            default_font: None,
+            code_font: None,
+            default_font_source: None,
+            code_font_source: None,
+            fallback_fonts: vec!["This_Font_Definitely_Does_Not_Exist_12345".to_string()],
+            fallback_font_sources: Vec::new(),
+            enable_subsetting: true,
+        };
+        let mut doc = PdfDocument::new("test");
+        let set = FontSet::load(Some(&cfg), &['日' as char], VariantUsage::default(), &mut doc);
+        assert!(set.fallbacks.is_empty());
+        // Uncovered codepoint must not panic; it routes through the
+        // primary's degraded path (`?` for built-in).
+        let chunks = set.split_for_emit(RunFlags::default(), "日", 12.0);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].needs_transliteration);
     }
 
     #[test]

--- a/src/lib/render/ir.rs
+++ b/src/lib/render/ir.rs
@@ -359,4 +359,22 @@ impl RunFlags {
         self.small = true;
         self
     }
+
+    /// OR every flag with `other`. Folds a block-level base style
+    /// (e.g. a heading's bold weight) into per-run inline flags so
+    /// the block style isn't lost when a run carries its own flags.
+    pub fn or(self, other: Self) -> Self {
+        Self {
+            bold: self.bold || other.bold,
+            italic: self.italic || other.italic,
+            monospace: self.monospace || other.monospace,
+            strikethrough: self.strikethrough || other.strikethrough,
+            underline: self.underline || other.underline,
+            highlight: self.highlight || other.highlight,
+            superscript: self.superscript || other.superscript,
+            subscript: self.subscript || other.subscript,
+            small_caps: self.small_caps || other.small_caps,
+            small: self.small || other.small,
+        }
+    }
 }

--- a/src/lib/render/ir.rs
+++ b/src/lib/render/ir.rs
@@ -177,6 +177,13 @@ pub struct VariantUsage {
     pub mono_bold: bool,
     pub mono_italic: bool,
     pub mono_bold_italic: bool,
+    /// Variants used by inline-code / `<kbd>` runs (separate from
+    /// fenced code blocks so a configured `[code_inline].font_family`
+    /// only loads the variants inline code actually references).
+    pub inline_code_regular: bool,
+    pub inline_code_bold: bool,
+    pub inline_code_italic: bool,
+    pub inline_code_bold_italic: bool,
 }
 
 impl VariantUsage {
@@ -280,6 +287,15 @@ fn walk_block(block: &Block, u: &mut VariantUsage) {
 
 fn walk_run(run: &InlineRun, u: &mut VariantUsage) {
     let f = run.flags;
+    if f.inline_code {
+        match (f.bold, f.italic) {
+            (false, false) => u.inline_code_regular = true,
+            (true, false) => u.inline_code_bold = true,
+            (false, true) => u.inline_code_italic = true,
+            (true, true) => u.inline_code_bold_italic = true,
+        }
+        return;
+    }
     match (f.monospace, f.bold, f.italic) {
         (false, false, false) => {}
         (false, true, false) => u.body_bold = true,
@@ -320,6 +336,12 @@ pub struct RunFlags {
     /// Renders at ~85% of body size on the original baseline. Set
     /// by `<small>` inline HTML.
     pub small: bool,
+    /// True for monospace runs that originated from `` `inline code` ``
+    /// or `<kbd>` (not fenced code blocks). When `[code_inline]
+    /// font_family` is configured, these runs route through a separate
+    /// `external_code_inline` family so inline code can use a different
+    /// monospace face than block code.
+    pub inline_code: bool,
 }
 
 impl RunFlags {
@@ -359,6 +381,11 @@ impl RunFlags {
         self.small = true;
         self
     }
+    pub fn with_inline_code(mut self) -> Self {
+        self.inline_code = true;
+        self.monospace = true;
+        self
+    }
 
     /// OR every flag with `other`. Folds a block-level base style
     /// (e.g. a heading's bold weight) into per-run inline flags so
@@ -375,6 +402,7 @@ impl RunFlags {
             subscript: self.subscript || other.subscript,
             small_caps: self.small_caps || other.small_caps,
             small: self.small || other.small,
+            inline_code: self.inline_code || other.inline_code,
         }
     }
 }

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -1810,7 +1810,6 @@ impl<'a> Engine<'a> {
         let before_pt = self.style.table.margin_before_pt;
         let after_pt = self.style.table.margin_after_pt;
         let row_gap_pt = self.style.table.row_gap_pt;
-        const CELL_PAD_PT: f32 = 4.0;
 
         self.advance_y(before_pt);
 
@@ -1908,7 +1907,6 @@ impl<'a> Engine<'a> {
             row_idx = group_end;
         }
 
-        let _ = CELL_PAD_PT;
         self.advance_y(after_pt);
     }
 
@@ -1921,6 +1919,7 @@ impl<'a> Engine<'a> {
         bold: bool,
     ) -> f32 {
         let line_h = font_size * line_height_mult.max(0.5);
+        let pad = self.style.table.cell_padding;
         let mut max_lines = 1usize;
         for cell in cells {
             if cell.covered {
@@ -1930,13 +1929,13 @@ impl<'a> Engine<'a> {
                 &cell.content,
                 font_size,
                 line_height_mult,
-                col_width * cell.colspan.max(1) as f32 - 8.0,
+                col_width * cell.colspan.max(1) as f32 - (pad.left + pad.right),
                 self.font_set,
                 bold,
             );
             max_lines = max_lines.max(n_lines);
         }
-        max_lines as f32 * line_h + 6.0
+        max_lines as f32 * line_h + pad.top + pad.bottom
     }
 
     fn measure_table_row_heights(
@@ -2002,7 +2001,7 @@ impl<'a> Engine<'a> {
         bold: bool,
         color: (u8, u8, u8),
     ) {
-        const CELL_PAD: f32 = 4.0;
+        let pad = self.style.table.cell_padding;
         let saved_left = self.indent_left_pt;
         let saved_right = self.indent_right_pt;
         let row_top = self.y_from_top_pt;
@@ -2014,8 +2013,8 @@ impl<'a> Engine<'a> {
             let colspan = cell.colspan.max(1).min(col_count - i);
             let rowspan = cell.rowspan.max(1).min(row_heights.len() - row_offset);
             let region_height: f32 = row_heights[row_offset..row_offset + rowspan].iter().sum();
-            let cell_left = saved_left + col_width * i as f32 + CELL_PAD;
-            let cell_right = saved_left + col_width * (i + colspan) as f32 - CELL_PAD;
+            let cell_left = saved_left + col_width * i as f32 + pad.left;
+            let cell_right = saved_left + col_width * (i + colspan) as f32 - pad.right;
             let inner_width = cell_right - cell_left;
             let mut runs = cell.content.clone();
             if bold {
@@ -2056,9 +2055,9 @@ impl<'a> Engine<'a> {
                 );
                 let content_height =
                     content_lines as f32 * font_size * line_height_mult.max(0.5);
-                row_top + ((region_height - content_height) / 2.0).max(3.0)
+                row_top + ((region_height - content_height) / 2.0).max(pad.top)
             } else {
-                row_top + 3.0
+                row_top + pad.top
             };
             self.write_wrapped_runs(
                 &runs,

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -3056,24 +3056,7 @@ fn emit_text_chunks(
 fn to_win1252(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
-        match c as u32 {
-            // ASCII passes through untouched.
-            0x00..=0x7F => out.push(c),
-            // Common Win-1252 punctuation -> ASCII equivalents.
-            0x2014 => out.push_str("--"),  // — em-dash
-            0x2013 => out.push('-'),       // – en-dash
-            0x2022 => out.push('*'),       // • bullet
-            0x2018 | 0x2019 => out.push('\''), // ' '
-            0x201C | 0x201D => out.push('"'),  // " "
-            0x2026 => out.push_str("..."), // …
-            0x00A0 => out.push(' '),       // non-breaking space
-            0x00A9 => out.push_str("(c)"),
-            0x00AE => out.push_str("(R)"),
-            0x2122 => out.push_str("(TM)"),
-            // Everything else is mapped to '?' so the loss is visible
-            // and not silently scrambled.
-            _ => out.push('?'),
-        }
+        super::font::for_each_builtin_emit_char(c, |emitted| out.push(emitted));
     }
     out
 }

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2469,6 +2469,7 @@ impl<'a> Engine<'a> {
         let base = base_flags_from_block(&s).with_monospace();
         let ctx = self.begin_block(&s);
         self.in_code_block = true;
+        self.current_text_align = s.text_align;
         for line in lines {
             let run = InlineRun { math: None,
                 text: line.clone(),
@@ -2483,6 +2484,7 @@ impl<'a> Engine<'a> {
                 color.clone(),
             );
         }
+        self.current_text_align = TextAlignment::Left;
         self.in_code_block = false;
         self.end_block(ctx);
     }

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -144,6 +144,13 @@ struct Engine<'a> {
     /// keep the `[code_block]` colour instead of being repainted with
     /// the `[code_inline]` colour (both carry the `monospace` flag).
     in_code_block: bool,
+    /// When set, paragraphs take their *text* style (font, colour,
+    /// weight, slant, size, alignment, decorations) from this block
+    /// instead of `[paragraph]` — so a blockquote's or admonition's
+    /// body text inherits the container's typography. Structural
+    /// fields (margins, padding, border, background) stay paragraph's,
+    /// since the container already draws its own box.
+    text_style_override: Option<ResolvedBlock>,
     /// Stack of block backgrounds currently open (LIFO — matches the
     /// nesting of `begin_block` / `end_block`). When a page break
     /// happens mid-block, [`start_new_page`] paints the fragment that
@@ -210,6 +217,7 @@ impl<'a> Engine<'a> {
             text_section_marker: 0,
             pending_highlights: Vec::new(),
             in_code_block: false,
+            text_style_override: None,
             open_bg: Vec::new(),
             math: None,
             math_inline_cache: HashMap::new(),
@@ -2286,9 +2294,12 @@ impl<'a> Engine<'a> {
         // it implicitly anymore.
         let s = self.style.blockquote.clone();
         let ctx = self.begin_block(&s);
+        let saved_override = self.text_style_override.take();
+        self.text_style_override = Some(s.clone());
         for child in body {
             self.render_block(child);
         }
+        self.text_style_override = saved_override;
         self.end_block(ctx);
     }
 
@@ -2397,9 +2408,12 @@ impl<'a> Engine<'a> {
         // Small gap between header and body.
         self.advance_y(block_style.font_size_pt * 0.35);
 
+        let saved_override = self.text_style_override.take();
+        self.text_style_override = Some(block_style.clone());
         for child in body {
             self.render_block(child);
         }
+        self.text_style_override = saved_override;
         self.end_block(ctx);
     }
 
@@ -2446,7 +2460,23 @@ impl<'a> Engine<'a> {
     }
 
     fn render_paragraph(&mut self, runs: &[InlineRun]) {
-        let s = self.style.paragraph.clone();
+        let mut s = self.style.paragraph.clone();
+        // Inside a blockquote / admonition, body paragraphs inherit
+        // the container's text typography; structural fields (margins,
+        // padding, border, background) stay paragraph's.
+        if let Some(ov) = &self.text_style_override {
+            s.font_family = ov.font_family.clone();
+            s.font_size_pt = ov.font_size_pt;
+            s.font_weight = ov.font_weight;
+            s.font_style = ov.font_style;
+            s.text_color = ov.text_color;
+            s.line_height = ov.line_height;
+            s.text_align = ov.text_align;
+            s.underline = ov.underline;
+            s.strikethrough = ov.strikethrough;
+            s.small_caps = ov.small_caps;
+            s.letter_spacing_pt = ov.letter_spacing_pt;
+        }
         let color = Some(rgb_color(s.text_color_rgb()));
         let base = base_flags_from_block(&s);
         let ctx = self.begin_block(&s);

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -155,6 +155,11 @@ struct Engine<'a> {
     /// call. Set by `render_paragraph` from `[paragraph].indent_pt`;
     /// the call consumes it (resets to 0) so it applies once.
     first_line_indent_pt: f32,
+    /// Extra spacing (points) added after every glyph of the block
+    /// currently being rendered. Set by `begin_block` from the block's
+    /// `letter_spacing_pt` and restored by `end_block`; read by both
+    /// `measure_text` and `emit_text_chunks` so the two never drift.
+    letter_spacing_pt: f32,
     /// Stack of block backgrounds currently open (LIFO — matches the
     /// nesting of `begin_block` / `end_block`). When a page break
     /// happens mid-block, [`start_new_page`] paints the fragment that
@@ -223,6 +228,7 @@ impl<'a> Engine<'a> {
             in_code_block: false,
             text_style_override: None,
             first_line_indent_pt: 0.0,
+            letter_spacing_pt: 0.0,
             open_bg: Vec::new(),
             math: None,
             math_inline_cache: HashMap::new(),
@@ -442,8 +448,50 @@ impl<'a> Engine<'a> {
         let top = mm_to_pt(self.style.page.margins_mm.top.max(1.0));
         let bottom = self.page_height_pt() - mm_to_pt(self.style.page.margins_mm.bottom.max(1.0));
         let usable_h = bottom - top;
+
+        // Optional cover image, centered above the title block. Scaled
+        // to fit the content width with height capped at ~45% of the
+        // usable page height so the title stack still fits.
+        let content_w = self.indent_right_pt - self.indent_left_pt;
+        let cover = tp
+            .cover_image_path
+            .as_deref()
+            .and_then(|p| self.decode_image_file(std::path::Path::new(p)))
+            .map(|raw| {
+                let nat_w = raw.width as f32 / 300.0 * 72.0;
+                let nat_h = raw.height as f32 / 300.0 * 72.0;
+                let scale = (content_w / nat_w)
+                    .min((usable_h * 0.45) / nat_h)
+                    .min(1.0);
+                (raw, nat_w * scale, nat_h * scale, scale)
+            });
+        if let Some((_, _, cover_h, _)) = &cover {
+            stack_h += cover_h + line_gap;
+        }
+
         let start_y = top + ((usable_h - stack_h) * 0.5).max(0.0);
         self.y_from_top_pt = start_y;
+
+        // Draw the cover image, then drop the cursor below it so the
+        // title stack renders underneath.
+        if let Some((raw, cover_w, cover_h, scale)) = cover {
+            let xobject_id: XObjectId = self.doc.add_image(&raw);
+            let x_pt = self.indent_left_pt + ((content_w - cover_w) * 0.5).max(0.0);
+            let y_bot_pt = self.page_height_pt() - self.y_from_top_pt - cover_h;
+            self.close_text_section();
+            self.page_ops.push(Op::UseXobject {
+                id: xobject_id,
+                transform: XObjectTransform {
+                    translate_x: Some(Pt(x_pt)),
+                    translate_y: Some(Pt(y_bot_pt)),
+                    rotate: None,
+                    scale_x: Some(scale),
+                    scale_y: Some(scale),
+                    dpi: Some(300.0),
+                },
+            });
+            self.y_from_top_pt += cover_h + line_gap;
+        }
 
         // Title (bold)
         self.render_title_page_text(
@@ -502,7 +550,7 @@ impl<'a> Engine<'a> {
             small: false,
             underline: false,
         };
-        let measured = self.font_set.measure(flags, text, size_pt);
+        let measured = self.measure_text(flags, text, size_pt);
         let center_x = (self.page_width_pt() - measured) / 2.0;
         let baseline_y = self.y_from_top_pt + size_pt;
 
@@ -512,7 +560,14 @@ impl<'a> Engine<'a> {
         self.page_ops.push(Op::SetFillColor {
             col: rgb_color(style.text_color_rgb()),
         });
-        emit_text_chunks(&mut self.page_ops, self.font_set, flags, text, size_pt);
+        emit_text_chunks(
+            &mut self.page_ops,
+            self.font_set,
+            flags,
+            text,
+            size_pt,
+            self.letter_spacing_pt,
+        );
         self.close_text_section();
 
         self.advance_y(size_pt);
@@ -636,11 +691,12 @@ impl<'a> Engine<'a> {
             flags,
             &anchor.text,
             size_pt,
+            self.letter_spacing_pt,
         );
 
         // Page-number portion (right-aligned at row_right).
         let page_str = page_num.to_string();
-        let num_w = self.font_set.measure(flags, &page_str, size_pt);
+        let num_w = self.measure_text(flags, &page_str, size_pt);
         let num_x = row_right - num_w;
         self.close_text_section();
         self.ensure_text_section();
@@ -651,6 +707,7 @@ impl<'a> Engine<'a> {
             flags,
             &page_str,
             size_pt,
+            self.letter_spacing_pt,
         );
         self.close_text_section();
 
@@ -776,13 +833,13 @@ impl<'a> Engine<'a> {
                 out.push(word);
                 continue;
             }
-            let total = self.font_set.measure(word.flags, &word.text, size_pt);
+            let total = self.measure_text(word.flags, &word.text, size_pt);
             if total <= max_width {
                 out.push(word);
                 continue;
             }
             let breaks = super::hyphenate::break_points(&word.text);
-            let hyphen_width = self.font_set.measure(word.flags, "-", size_pt);
+            let hyphen_width = self.measure_text(word.flags, "-", size_pt);
             let chars: Vec<(usize, char)> = word.text.char_indices().collect();
             let mut chunk_start_byte = 0usize;
             let mut chunk_start_char = 0usize;
@@ -796,7 +853,7 @@ impl<'a> Engine<'a> {
                         continue;
                     }
                     let prefix = &word.text[chunk_start_byte..b];
-                    let w = self.font_set.measure(word.flags, prefix, size_pt) + hyphen_width;
+                    let w = self.measure_text(word.flags, prefix, size_pt) + hyphen_width;
                     if w <= max_width {
                         hyphen_break = Some(b);
                     } else {
@@ -828,7 +885,7 @@ impl<'a> Engine<'a> {
                         .map(|c| c.0)
                         .unwrap_or(word.text.len());
                     let prefix = &word.text[chunk_start_byte..end_byte];
-                    let w = self.font_set.measure(word.flags, prefix, size_pt);
+                    let w = self.measure_text(word.flags, prefix, size_pt);
                     if w > max_width {
                         if last_fit == chunk_start_char {
                             last_fit = j;
@@ -1004,6 +1061,9 @@ impl<'a> Engine<'a> {
             });
         }
 
+        let saved_letter_spacing = self.letter_spacing_pt;
+        self.letter_spacing_pt = style.letter_spacing_pt;
+
         BlockPaintCtx {
             saved_left: outer_x_left,
             saved_right: outer_x_right,
@@ -1014,6 +1074,7 @@ impl<'a> Engine<'a> {
             border: style.border.clone(),
             padding_bottom: style.padding.bottom,
             margin_after_pt: style.margin_after_pt,
+            saved_letter_spacing,
         }
     }
 
@@ -1067,6 +1128,7 @@ impl<'a> Engine<'a> {
 
         self.indent_left_pt = ctx.saved_left;
         self.indent_right_pt = ctx.saved_right;
+        self.letter_spacing_pt = ctx.saved_letter_spacing;
         self.advance_y(ctx.margin_after_pt);
     }
 
@@ -1136,7 +1198,7 @@ impl<'a> Engine<'a> {
             underline: false,
         };
         let size_pt = style.font_size_pt;
-        let measured = self.font_set.measure(flags, text, size_pt);
+        let measured = self.measure_text(flags, text, size_pt);
         let x_pt = match anchor {
             FurnitureAnchor::Left => mm_to_pt(self.style.page.margins_mm.left.max(1.0)),
             FurnitureAnchor::Center => (self.page_width_pt() - measured) / 2.0,
@@ -1158,7 +1220,14 @@ impl<'a> Engine<'a> {
         ops.push(Op::SetFillColor {
             col: rgb_color(style.text_color_rgb()),
         });
-        emit_text_chunks(ops, self.font_set, flags, text, size_pt);
+        emit_text_chunks(
+            ops,
+            self.font_set,
+            flags,
+            text,
+            size_pt,
+            self.letter_spacing_pt,
+        );
         ops.push(Op::EndTextSection);
         ops.push(Op::RestoreGraphicsState);
     }
@@ -1646,14 +1715,11 @@ impl<'a> Engine<'a> {
         }]);
     }
 
-    fn render_image(&mut self, path: &std::path::Path, alt: &str, caption: Option<&str>) {
-        // Decode via the `image` crate. If anything fails, gracefully
-        // degrade to an italic alt-text paragraph so the document
-        // doesn't lose content. URL paths take a separate fetch
-        // pre-pass that downloads the bytes (gated under the `fetch`
-        // feature); without the feature, URL images fall back to alt
-        // text. SVG content is rasterized via resvg (gated under
-        // `svg`).
+    /// Decode an image from a local path or URL into a `RawImage`,
+    /// applying the 4000px dimension cap. Returns `None` on any
+    /// fetch / decode / conversion failure (logged). URL fetch is
+    /// gated under the `fetch` feature; SVG rasterization under `svg`.
+    fn decode_image_file(&mut self, path: &std::path::Path) -> Option<RawImage> {
         let path_str = path.to_string_lossy();
         let is_url = path_str.starts_with("http://") || path_str.starts_with("https://");
         let bytes_result: Result<Vec<u8>, String> = if is_url {
@@ -1676,8 +1742,7 @@ impl<'a> Engine<'a> {
             Ok(d) => d,
             Err(e) => {
                 log::warn!("could not decode image {:?}: {}", path, e);
-                self.render_image_fallback(alt);
-                return;
+                return None;
             }
         };
 
@@ -1685,8 +1750,7 @@ impl<'a> Engine<'a> {
         // XObject. Treat it like a decode failure.
         if img.width() == 0 || img.height() == 0 {
             log::warn!("image {:?} has zero dimension; skipping", path);
-            self.render_image_fallback(alt);
-            return;
+            return None;
         }
 
         // Bound decoded pixel dimensions. The URL fetch cap limits the
@@ -1712,10 +1776,21 @@ impl<'a> Engine<'a> {
             img
         };
 
-        let raw = match RawImage::from_dynamic_image(img) {
-            Ok(r) => r,
+        match RawImage::from_dynamic_image(img) {
+            Ok(r) => Some(r),
             Err(e) => {
                 log::warn!("could not convert image {:?}: {}", path, e);
+                None
+            }
+        }
+    }
+
+    fn render_image(&mut self, path: &std::path::Path, alt: &str, caption: Option<&str>) {
+        // Decode the image; on any failure degrade to an italic
+        // alt-text paragraph so the document doesn't lose content.
+        let raw = match self.decode_image_file(path) {
+            Some(r) => r,
+            None => {
                 self.render_image_fallback(alt);
                 return;
             }
@@ -1775,32 +1850,35 @@ impl<'a> Engine<'a> {
         self.y_from_top_pt += rendered_h_pt;
 
         if let Some(text) = caption.filter(|s| !s.trim().is_empty()) {
-            // Small gap, then a caption line styled as italic body text
-            // centered horizontally inside the image's content column.
-            self.advance_y(4.0);
-            let base = self.style.paragraph.clone();
-            let caption_size = base.font_size_pt * 0.88;
+            // Caption line styled by `[image.caption]`, wrapped within
+            // the image's width when the image is narrower than the
+            // column.
+            let cap = self.style.image.caption.clone();
+            self.advance_y(cap.margin_before_pt);
+            let base_flags = base_flags_from_block(&cap);
             let saved_left = self.indent_left_pt;
             let saved_right = self.indent_right_pt;
-            // Constrain the caption's wrap width to the image width
-            // when the image is narrower than the column.
             if rendered_w_pt < self.content_width_pt() {
                 self.indent_left_pt = x_pt;
                 self.indent_right_pt = x_pt + rendered_w_pt;
             }
-            let runs = vec![InlineRun { math: None,
+            let runs = vec![InlineRun {
+                math: None,
                 text: text.to_string(),
-                flags: RunFlags::default().with_italic(),
+                flags: RunFlags::default(),
                 link: None,
             }];
-            let color = Some(rgb_color(base.text_color_rgb()));
+            let color = Some(rgb_color(cap.text_color_rgb()));
+            let saved_align = self.current_text_align;
+            self.current_text_align = cap.text_align;
             self.write_wrapped_runs(
                 &runs,
-                caption_size,
-                base.line_height,
-                RunFlags::default().with_italic(),
+                cap.font_size_pt,
+                cap.line_height,
+                base_flags,
                 color,
             );
+            self.current_text_align = saved_align;
             self.indent_left_pt = saved_left;
             self.indent_right_pt = saved_right;
         }
@@ -1825,6 +1903,11 @@ impl<'a> Engine<'a> {
         let before_pt = self.style.table.margin_before_pt;
         let after_pt = self.style.table.margin_after_pt;
         let row_gap_pt = self.style.table.row_gap_pt;
+        // Tables don't go through begin_block; scope letter spacing
+        // here — header cells use `[table.header]`, data cells
+        // `[table.cell]`.
+        let saved_letter_spacing = self.letter_spacing_pt;
+        self.letter_spacing_pt = s_header.letter_spacing_pt;
 
         self.advance_y(before_pt);
 
@@ -1867,6 +1950,7 @@ impl<'a> Engine<'a> {
         self.advance_y(row_gap_pt);
 
         // Data rows.
+        self.letter_spacing_pt = s_cell.letter_spacing_pt;
         let mut table_rows: Vec<Vec<TableCell<InlineRun>>> = rows.to_vec();
         for row in &mut table_rows {
             row.resize_with(col_count, || TableCell::new(Vec::new()));
@@ -1942,6 +2026,7 @@ impl<'a> Engine<'a> {
             row_idx = group_end;
         }
 
+        self.letter_spacing_pt = saved_letter_spacing;
         self.advance_y(after_pt);
     }
 
@@ -1967,6 +2052,7 @@ impl<'a> Engine<'a> {
                 col_width * cell.colspan.max(1) as f32 - (pad.left + pad.right),
                 self.font_set,
                 bold,
+                self.letter_spacing_pt,
             );
             max_lines = max_lines.max(n_lines);
         }
@@ -2012,6 +2098,16 @@ impl<'a> Engine<'a> {
     /// Sum the rendered widths of a cell's inline runs (no wrapping).
     /// Used for table column alignment — we shift the per-cell text
     /// cursor by `(col_width - measured) / 2` for center, etc.
+    /// Rendered width of `text`, including the active block's letter
+    /// spacing. `letter_spacing_pt` is added after every glyph, so an
+    /// N-char run measures `font_set.measure() + N * letter_spacing_pt`
+    /// — exactly matching the PDF text-cursor advance, so measurement
+    /// and emission never drift.
+    fn measure_text(&self, flags: RunFlags, text: &str, size_pt: f32) -> f32 {
+        self.font_set.measure(flags, text, size_pt)
+            + self.letter_spacing_pt * text.chars().count() as f32
+    }
+
     fn measure_runs_width(&self, runs: &[InlineRun], font_size: f32, bold: bool) -> f32 {
         let mut total = 0.0f32;
         for run in runs {
@@ -2019,7 +2115,7 @@ impl<'a> Engine<'a> {
             if bold {
                 flags = flags.with_bold();
             }
-            total += self.font_set.measure(flags, &run.text, font_size);
+            total += self.measure_text(flags, &run.text, font_size);
         }
         total
     }
@@ -2087,6 +2183,7 @@ impl<'a> Engine<'a> {
                     inner_width,
                     self.font_set,
                     false,
+                    self.letter_spacing_pt,
                 );
                 let content_height =
                     content_lines as f32 * font_size * line_height_mult.max(0.5);
@@ -2148,6 +2245,9 @@ impl<'a> Engine<'a> {
 
     fn render_list(&mut self, entries: &[ListEntry]) {
         let saved_left = self.indent_left_pt;
+        // Lists don't go through begin_block; scope letter spacing here
+        // so list text honors `[list.*].letter_spacing_pt`.
+        let saved_letter_spacing = self.letter_spacing_pt;
 
         // CommonMark §5.3: the whole list is loose if any item is loose.
         // Pre-compute once so every iteration uses the same gap.
@@ -2162,6 +2262,7 @@ impl<'a> Engine<'a> {
                 }
             };
             let s = &list_style.block;
+            self.letter_spacing_pt = s.letter_spacing_pt;
             let size_pt = s.font_size_pt;
             let line_height = s.line_height;
             let inter_item_gap = if any_loose {
@@ -2172,7 +2273,7 @@ impl<'a> Engine<'a> {
 
             let bullet_text = format_bullet(&entry.bullet, &list_style);
             let bullet_flags = RunFlags::default();
-            let bullet_width = self.font_set.measure(bullet_flags, &bullet_text, size_pt);
+            let bullet_width = self.measure_text(bullet_flags, &bullet_text, size_pt);
 
             // First item: honor `block.margin_before_pt` (list-level
             // "space before the whole list"). Subsequent items use the
@@ -2258,6 +2359,7 @@ impl<'a> Engine<'a> {
                         bullet_flags,
                         &bullet_text,
                         size_pt,
+                        self.letter_spacing_pt,
                     );
                 }
             }
@@ -2297,6 +2399,7 @@ impl<'a> Engine<'a> {
                 self.advance_y(s.margin_after_pt.max(0.0));
             }
         }
+        self.letter_spacing_pt = saved_letter_spacing;
     }
 
     fn render_blockquote(&mut self, body: &[Block]) {
@@ -2631,7 +2734,7 @@ impl<'a> Engine<'a> {
                     .inline_math_frag(tex, size_pt)
                     .map(|f| f.w)
                     .unwrap_or(0.0),
-                None => self.font_set.measure(word.flags, &word.text, size_pt),
+                None => self.measure_text(word.flags, &word.text, size_pt),
             };
 
             // The first line is narrowed by the first-line indent.
@@ -2731,7 +2834,7 @@ impl<'a> Engine<'a> {
                 } else {
                     size_pt
                 };
-                natural_w_pt += self.font_set.measure(seg.flags, &seg.text, s_size);
+                natural_w_pt += self.measure_text(seg.flags, &seg.text, s_size);
                 if seg.text.chars().all(char::is_whitespace) && !seg.text.is_empty() {
                     space_count += 1;
                 }
@@ -2829,7 +2932,7 @@ impl<'a> Engine<'a> {
                 } else {
                     (size_pt, baseline_y_pt)
                 };
-                let seg_width = self.font_set.measure(seg.flags, &seg.text, seg_size);
+                let seg_width = self.measure_text(seg.flags, &seg.text, seg_size);
 
                 if seg.flags.superscript || seg.flags.subscript {
                     // Close the line's main section, emit the small
@@ -2853,6 +2956,7 @@ impl<'a> Engine<'a> {
                         seg.flags,
                         &seg.text,
                         seg_size,
+                        self.letter_spacing_pt,
                     );
                     self.page_ops.push(Op::EndTextSection);
                     self.page_ops.push(Op::RestoreGraphicsState);
@@ -2904,6 +3008,7 @@ impl<'a> Engine<'a> {
                         seg.flags,
                         &seg.text,
                         seg_size,
+                        self.letter_spacing_pt,
                     );
                 }
 
@@ -3086,6 +3191,7 @@ struct BlockPaintCtx {
     border: ResolvedBorder,
     padding_bottom: f32,
     margin_after_pt: f32,
+    saved_letter_spacing: f32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -3132,7 +3238,17 @@ fn emit_text_chunks(
     flags: RunFlags,
     text: &str,
     size_pt: f32,
+    letter_spacing_pt: f32,
 ) {
+    // `Tc` adds spacing after every glyph. Emit it only when set —
+    // a zero value leaves the op out so non-letter-spaced documents
+    // render byte-identically. `Tc` is reset by the next `BT`, so a
+    // block keeps its own spacing without leaking to the next.
+    if letter_spacing_pt != 0.0 {
+        ops.push(Op::SetCharacterSpacing {
+            multiplier: letter_spacing_pt,
+        });
+    }
     for chunk in font_set.split_for_emit(flags, text, size_pt) {
         ops.push(Op::SetFont {
             font: chunk.handle,
@@ -3184,11 +3300,16 @@ fn count_wrapped_lines(
     max_width: f32,
     font_set: &FontSet,
     bold: bool,
+    letter_spacing_pt: f32,
 ) -> usize {
     if runs.is_empty() {
         return 1;
     }
     let size_pt = font_size;
+    let measure = |flags: RunFlags, text: &str| {
+        font_set.measure(flags, text, size_pt)
+            + letter_spacing_pt * text.chars().count() as f32
+    };
     let mut current = 0.0f32;
     let mut lines = 1usize;
     for run in runs {
@@ -3197,8 +3318,8 @@ fn count_wrapped_lines(
             flags = flags.with_bold();
         }
         for word in run.text.split_whitespace() {
-            let w = font_set.measure(flags, word, size_pt);
-            let space = font_set.measure(flags, " ", size_pt);
+            let w = measure(flags, word);
+            let space = measure(flags, " ");
             if current + w > max_width {
                 lines += 1;
                 current = w + space;

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -549,6 +549,7 @@ impl<'a> Engine<'a> {
             small_caps: false,
             small: false,
             underline: false,
+            inline_code: false,
         };
         let measured = self.measure_text(flags, text, size_pt);
         let center_x = (self.page_width_pt() - measured) / 2.0;
@@ -649,6 +650,7 @@ impl<'a> Engine<'a> {
             small_caps: false,
             small: false,
             underline: false,
+            inline_code: false,
         };
         let ctx = self.begin_block(&s);
         self.write_wrapped_runs(&runs, s.font_size_pt, s.line_height, flags, color);
@@ -1008,9 +1010,9 @@ impl<'a> Engine<'a> {
             draw_filled_rect(
                 &mut bg_ops,
                 b.x0_pt,
-                b.baseline_y_pt - b.size_pt * 0.80,
+                b.baseline_y_pt - b.size_pt * 0.80 - b.pad_top_pt,
                 b.x1_pt,
-                b.baseline_y_pt + b.size_pt * 0.20,
+                b.baseline_y_pt + b.size_pt * 0.20 + b.pad_bottom_pt,
                 b.fill.clone(),
                 page_h_pt,
             );
@@ -1196,6 +1198,7 @@ impl<'a> Engine<'a> {
             small_caps: false,
             small: false,
             underline: false,
+            inline_code: false,
         };
         let size_pt = style.font_size_pt;
         let measured = self.measure_text(flags, text, size_pt);
@@ -1601,6 +1604,7 @@ impl<'a> Engine<'a> {
             subscript: false,
             small_caps: false,
             small: false,
+            inline_code: false,
         };
         let ctx = self.begin_block(&h2);
         self.write_wrapped_runs(&title_runs, h2.font_size_pt, h2.line_height, flags, color);
@@ -2254,13 +2258,26 @@ impl<'a> Engine<'a> {
         let any_loose = entries.iter().any(|e| e.loose);
 
         for (idx, entry) in entries.iter().enumerate() {
-            let list_style: ResolvedList = match entry.bullet {
+            let mut list_style: ResolvedList = match entry.bullet {
                 ListBullet::Unordered(_) => self.style.list_unordered.clone(),
                 ListBullet::Ordered(_) => self.style.list_ordered.clone(),
                 ListBullet::TaskChecked | ListBullet::TaskUnchecked => {
                     self.style.list_task.clone()
                 }
             };
+            // Inside a blockquote / admonition, list text inherits the
+            // container typography (the same fields a body paragraph
+            // does); bullet glyphs, indents and spacing stay the list's.
+            if let Some(ov) = &self.text_style_override {
+                let b = &mut list_style.block;
+                b.font_family = ov.font_family.clone();
+                b.font_size_pt = ov.font_size_pt;
+                b.font_weight = ov.font_weight;
+                b.font_style = ov.font_style;
+                b.text_color = ov.text_color;
+                b.line_height = ov.line_height;
+                b.letter_spacing_pt = ov.letter_spacing_pt;
+            }
             let s = &list_style.block;
             self.letter_spacing_pt = s.letter_spacing_pt;
             let size_pt = s.font_size_pt;
@@ -2372,7 +2389,7 @@ impl<'a> Engine<'a> {
                 &entry.runs,
                 size_pt,
                 line_height,
-                RunFlags::default(),
+                base_flags_from_block(s),
                 Some(rgb_color(s.text_color_rgb())),
             );
 
@@ -2727,18 +2744,47 @@ impl<'a> Engine<'a> {
         // chopped at character boundaries so the chunks each fit. URLs,
         // long identifiers, CJK runs without spaces, etc.
         words = self.split_long_words(words, max_width, size_pt);
+        // `[code_inline].padding` is applied to the first / last word
+        // of each contiguous inline-code span: pad.left on the first,
+        // pad.right on the last. Middle words and runs that aren't
+        // inline-code get (0, 0), so a non-inline-code document picks
+        // up no per-word overhead.
+        let ci_pad_l = self.style.code_inline.padding.left;
+        let ci_pad_r = self.style.code_inline.padding.right;
+        let is_inline_code_word = |w: &InlineRun| {
+            w.math.is_none() && w.flags.inline_code && !self.in_code_block
+        };
+        let word_pads: Vec<(f32, f32)> = if ci_pad_l == 0.0 && ci_pad_r == 0.0 {
+            vec![(0.0, 0.0); words.len()]
+        } else {
+            (0..words.len())
+                .map(|i| {
+                    if !is_inline_code_word(&words[i]) {
+                        return (0.0, 0.0);
+                    }
+                    let prev_ic = i > 0 && is_inline_code_word(&words[i - 1]);
+                    let next_ic = i + 1 < words.len() && is_inline_code_word(&words[i + 1]);
+                    (
+                        if prev_ic { 0.0 } else { ci_pad_l },
+                        if next_ic { 0.0 } else { ci_pad_r },
+                    )
+                })
+                .collect()
+        };
         let mut lines: Vec<Vec<TextSegment>> = Vec::new();
         let mut current: Vec<TextSegment> = Vec::new();
         let mut current_width = 0.0f32;
 
-        for word in &words {
+        for (wi, word) in words.iter().enumerate() {
+            let (pad_before_pt, pad_after_pt) = word_pads[wi];
             let word_width = match &word.math {
                 Some(tex) => self
                     .inline_math_frag(tex, size_pt)
                     .map(|f| f.w)
                     .unwrap_or(0.0),
                 None => self.measure_text(word.flags, &word.text, size_pt),
-            };
+            } + pad_before_pt
+                + pad_after_pt;
 
             // The first line is narrowed by the first-line indent.
             let line_limit = if lines.is_empty() {
@@ -2762,6 +2808,8 @@ impl<'a> Engine<'a> {
                 flags: word.flags,
                 link: word.link.clone(),
                 math: word.math.clone(),
+                pad_before_pt,
+                pad_after_pt,
             });
             current_width += word_width;
         }
@@ -2775,7 +2823,9 @@ impl<'a> Engine<'a> {
         // wrapping is settled, those pieces can collapse back into
         // one `ShowText` per same-style run. Fewer Tj operators =
         // tighter selection highlights with no visual gap between
-        // logically-contiguous text.
+        // logically-contiguous text. The merged seg keeps the leader's
+        // `pad_before_pt` and takes on the trailer's `pad_after_pt`
+        // (middle words contribute 0 on both sides by construction).
         for line in &mut lines {
             line.dedup_by(|next, prev| {
                 if prev.math.is_none()
@@ -2784,6 +2834,7 @@ impl<'a> Engine<'a> {
                     && prev.link == next.link
                 {
                     prev.text.push_str(&next.text);
+                    prev.pad_after_pt = next.pad_after_pt;
                     true
                 } else {
                     false
@@ -2839,7 +2890,9 @@ impl<'a> Engine<'a> {
                 } else {
                     size_pt
                 };
-                natural_w_pt += self.measure_text(seg.flags, &seg.text, s_size);
+                natural_w_pt += self.measure_text(seg.flags, &seg.text, s_size)
+                    + seg.pad_before_pt
+                    + seg.pad_after_pt;
                 if seg.text.chars().all(char::is_whitespace) && !seg.text.is_empty() {
                     space_count += 1;
                 }
@@ -2953,14 +3006,20 @@ impl<'a> Engine<'a> {
                 // not include that, so the cursor and decoration rects
                 // must add `word_spacing_pt` per space or underlines /
                 // link boxes drift left of the text. Super/subscript
-                // segments break into their own `Tw`-free section.
-                let seg_advance = seg_width
+                // segments break into their own `Tw`-free section, and
+                // an inline-code span at the boundary contributes
+                // `pad_before_pt + pad_after_pt` of horizontal gap
+                // around its glyphs.
+                let pad_before_pt = seg.pad_before_pt;
+                let pad_after_pt = seg.pad_after_pt;
+                let glyph_advance = seg_width
                     + if seg.flags.superscript || seg.flags.subscript {
                         0.0
                     } else {
                         word_spacing_pt
                             * seg.text.chars().filter(|&c| c == ' ').count() as f32
                     };
+                let seg_advance = pad_before_pt + glyph_advance + pad_after_pt;
 
                 if seg.flags.superscript || seg.flags.subscript {
                     // Close the line's main section, emit the small
@@ -3030,6 +3089,16 @@ impl<'a> Engine<'a> {
                     } else if let Some(c) = color.clone() {
                         self.page_ops.push(Op::SetFillColor { col: c });
                     }
+                    // Insert the inline-code left padding as a TJ
+                    // negative offset (in thousandths of em) — moves
+                    // the text cursor right by `pad_before_pt` without
+                    // emitting a glyph, so the inline-code text starts
+                    // `pad_before_pt` past the previous seg's end.
+                    if pad_before_pt > 0.0 {
+                        self.page_ops.push(Op::ShowText {
+                            items: vec![TextItem::Offset(-pad_before_pt * 1000.0 / seg_size)],
+                        });
+                    }
                     emit_text_chunks(
                         &mut self.page_ops,
                         self.font_set,
@@ -3038,6 +3107,11 @@ impl<'a> Engine<'a> {
                         seg_size,
                         self.letter_spacing_pt,
                     );
+                    if pad_after_pt > 0.0 {
+                        self.page_ops.push(Op::ShowText {
+                            items: vec![TextItem::Offset(-pad_after_pt * 1000.0 / seg_size)],
+                        });
+                    }
                 }
 
                 // Buffer decorations and link rects until the line is
@@ -3069,8 +3143,8 @@ impl<'a> Engine<'a> {
                         } else {
                             DecorationKind::None
                         },
-                        x0_pt: x_cursor_pt,
-                        x1_pt: x_cursor_pt + seg_advance,
+                        x0_pt: x_cursor_pt + pad_before_pt,
+                        x1_pt: x_cursor_pt + pad_before_pt + glyph_advance,
                         y_pt: decoration_y_pt,
                         link: seg.link.clone(),
                         size_pt,
@@ -3079,6 +3153,9 @@ impl<'a> Engine<'a> {
                 }
                 // Inline background box: `[mark]` fill for a highlight,
                 // `[code_inline]` fill for inline code (not code blocks).
+                // Inline-code boxes span the full padded extent (the
+                // padding is the *whole point* of the box — it sits
+                // outside the text); mark highlights carry no padding.
                 let inline_bg = if seg.flags.highlight {
                     self.style.mark.background_color_rgb()
                 } else if seg.flags.monospace && !self.in_code_block {
@@ -3087,12 +3164,23 @@ impl<'a> Engine<'a> {
                     None
                 };
                 if let Some(rgb) = inline_bg {
+                    let is_ic_box = seg.flags.monospace && !self.in_code_block;
+                    let (pad_top, pad_bot) = if is_ic_box {
+                        (
+                            self.style.code_inline.padding.top,
+                            self.style.code_inline.padding.bottom,
+                        )
+                    } else {
+                        (0.0, 0.0)
+                    };
                     self.pending_highlights.push(HighlightBox {
                         x0_pt: x_cursor_pt,
                         x1_pt: x_cursor_pt + seg_advance,
                         baseline_y_pt,
                         size_pt,
                         fill: rgb_color(rgb),
+                        pad_top_pt: pad_top,
+                        pad_bottom_pt: pad_bot,
                     });
                 }
                 x_cursor_pt += seg_advance;
@@ -3260,6 +3348,12 @@ struct HighlightBox {
     baseline_y_pt: f32,
     size_pt: f32,
     fill: Color,
+    /// Extra pt above the natural top edge (inline-code
+    /// `padding.top`). Zero for `==mark==` highlights.
+    pad_top_pt: f32,
+    /// Extra pt below the natural bottom edge (inline-code
+    /// `padding.bottom`).
+    pad_bottom_pt: f32,
 }
 
 /// Emit `text` at `size_pt` using the run flags' resolved font chain.
@@ -3927,6 +4021,14 @@ struct TextSegment {
     link: Option<String>,
     /// Raw TeX when this segment is an inline-math box (`text` empty).
     math: Option<String>,
+    /// Horizontal pt of padding to insert before this segment's glyphs
+    /// (and after, respectively). Non-zero only for the first / last
+    /// segment of a contiguous inline-code span when
+    /// `[code_inline].padding.left` / `.right` are set. Emitted as a
+    /// `TextItem::Offset` so the gap lives inside the line's BT and
+    /// text selection stays contiguous.
+    pad_before_pt: f32,
+    pad_after_pt: f32,
 }
 
 /// Flatten a run list to a sequence of (word | whitespace) pieces,

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2570,6 +2570,7 @@ impl<'a> Engine<'a> {
             runs
         };
         self.current_text_align = s.text_align;
+        self.first_line_indent_pt = s.indent_pt;
         self.write_wrapped_runs(runs_ref, s.font_size_pt, s.line_height, base_flags, color);
         self.current_text_align = TextAlignment::Left;
         self.end_block(ctx);
@@ -2592,6 +2593,7 @@ impl<'a> Engine<'a> {
             s.strikethrough = ov.strikethrough;
             s.small_caps = ov.small_caps;
             s.letter_spacing_pt = ov.letter_spacing_pt;
+            s.indent_pt = ov.indent_pt;
         }
         let color = Some(rgb_color(s.text_color_rgb()));
         let base = base_flags_from_block(&s);
@@ -2617,6 +2619,7 @@ impl<'a> Engine<'a> {
         let ctx = self.begin_block(&s);
         self.in_code_block = true;
         self.current_text_align = s.text_align;
+        self.first_line_indent_pt = s.indent_pt;
         for line in lines {
             let run = InlineRun { math: None,
                 text: line.clone(),
@@ -2798,6 +2801,8 @@ impl<'a> Engine<'a> {
         self.close_text_section();
         let align = self.current_text_align;
         let last_line_idx = lines.len().saturating_sub(1);
+        let mut prev_line_x_start = 0.0f32;
+        let mut prev_baseline_y_pt = 0.0f32;
         for (line_idx, line) in lines.iter().enumerate() {
             // One BT...ET block per paragraph, not per line — PDF
             // viewers use text-block boundaries to determine
@@ -2882,10 +2887,20 @@ impl<'a> Engine<'a> {
                     self.page_ops.push(Op::SetFillColor { col: c });
                 }
             } else if needs_absolute_td {
-                self.move_cursor_to(line_x_start, baseline_y_pt);
+                // `Td` moves relative to the previous line's origin,
+                // not absolutely — center/right lines each have a
+                // different left edge, so emit the delta from the
+                // previous line (x shift, one line down).
+                let dx = line_x_start - prev_line_x_start;
+                let dy = -(baseline_y_pt - prev_baseline_y_pt);
+                self.page_ops.push(Op::SetTextCursor {
+                    pos: Point::new(Mm(pt_to_mm(dx)), Mm(pt_to_mm(dy))),
+                });
             } else {
                 self.page_ops.push(Op::AddLineBreak);
             }
+            prev_line_x_start = line_x_start;
+            prev_baseline_y_pt = baseline_y_pt;
 
             // Justify uses the PDF Tw operator (set word spacing) so
             // every space char picks up the extra slack. Set it before
@@ -3027,20 +3042,29 @@ impl<'a> Engine<'a> {
 
                 // Buffer decorations and link rects until the line is
                 // finished — they need a closed text section to draw
-                // paths on top.
-                // A link is underlined only when `[link].underline`
-                // is set; `<u>` text always is.
+                // paths on top. Underline / strikethrough come from the
+                // run flags (`<u>`, `~~`), from `[link]` for links, and
+                // from `[code_inline]` / `[mark]` for inline code and
+                // highlighted spans.
                 let link_underline = seg.link.is_some() && self.style.link.underline;
-                if seg.flags.underline || seg.flags.strikethrough || seg.link.is_some() {
-                    let decoration_y_pt = if seg.flags.strikethrough {
+                let is_inline_code = seg.flags.monospace && !self.in_code_block;
+                let dec_underline = seg.flags.underline
+                    || link_underline
+                    || (is_inline_code && self.style.code_inline.underline)
+                    || (seg.flags.highlight && self.style.mark.underline);
+                let dec_strike = seg.flags.strikethrough
+                    || (is_inline_code && self.style.code_inline.strikethrough)
+                    || (seg.flags.highlight && self.style.mark.strikethrough);
+                if dec_underline || dec_strike || seg.link.is_some() {
+                    let decoration_y_pt = if dec_strike {
                         baseline_y_pt - size_pt * 0.30
                     } else {
                         baseline_y_pt + size_pt * 0.12
                     };
                     self.pending_decorations.push(PendingDecoration {
-                        kind: if seg.flags.strikethrough {
+                        kind: if dec_strike {
                             DecorationKind::Strike
-                        } else if seg.flags.underline || link_underline {
+                        } else if dec_underline {
                             DecorationKind::Underline
                         } else {
                             DecorationKind::None

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2933,6 +2933,19 @@ impl<'a> Engine<'a> {
                     (size_pt, baseline_y_pt)
                 };
                 let seg_width = self.measure_text(seg.flags, &seg.text, seg_size);
+                // Justified lines widen every space via the PDF `Tw`
+                // operator. `seg_width` (glyphs + letter spacing) does
+                // not include that, so the cursor and decoration rects
+                // must add `word_spacing_pt` per space or underlines /
+                // link boxes drift left of the text. Super/subscript
+                // segments break into their own `Tw`-free section.
+                let seg_advance = seg_width
+                    + if seg.flags.superscript || seg.flags.subscript {
+                        0.0
+                    } else {
+                        word_spacing_pt
+                            * seg.text.chars().filter(|&c| c == ' ').count() as f32
+                    };
 
                 if seg.flags.superscript || seg.flags.subscript {
                     // Close the line's main section, emit the small
@@ -3033,7 +3046,7 @@ impl<'a> Engine<'a> {
                             DecorationKind::None
                         },
                         x0_pt: x_cursor_pt,
-                        x1_pt: x_cursor_pt + seg_width,
+                        x1_pt: x_cursor_pt + seg_advance,
                         y_pt: decoration_y_pt,
                         link: seg.link.clone(),
                         size_pt,
@@ -3052,13 +3065,13 @@ impl<'a> Engine<'a> {
                 if let Some(rgb) = inline_bg {
                     self.pending_highlights.push(HighlightBox {
                         x0_pt: x_cursor_pt,
-                        x1_pt: x_cursor_pt + seg_width,
+                        x1_pt: x_cursor_pt + seg_advance,
                         baseline_y_pt,
                         size_pt,
                         fill: rgb_color(rgb),
                     });
                 }
-                x_cursor_pt += seg_width;
+                x_cursor_pt += seg_advance;
             }
 
             // A line that had any superscript break also has its

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -1887,6 +1887,26 @@ impl<'a> Engine<'a> {
                 self.advance_y(row_gap_pt);
             }
             let group_top = self.y_from_top_pt;
+            // Zebra striping: tint alternate data rows (every other
+            // row, first data row left untinted) when configured.
+            if let Some(bg) = self.style.table.alternating_row_background {
+                if row_idx % 2 == 1 {
+                    let table_left = self.indent_left_pt;
+                    let table_right = table_left + col_width * col_count as f32;
+                    let page_h = self.page_height_pt();
+                    let fill = rgb_color((bg.r, bg.g, bg.b));
+                    self.close_text_section();
+                    draw_filled_rect(
+                        &mut self.page_ops,
+                        table_left,
+                        group_top,
+                        table_right,
+                        group_top + group_height,
+                        fill,
+                        page_h,
+                    );
+                }
+            }
             let group_heights = &row_heights[row_idx..group_end];
             for local_idx in 0..(group_end - row_idx) {
                 self.y_from_top_pt = group_top + group_heights[..local_idx].iter().sum::<f32>();
@@ -2604,6 +2624,7 @@ impl<'a> Engine<'a> {
         }
 
         let link_color = Some(rgb_color(self.style.link.text_color_rgb()));
+        let mark_color = rgb_color(self.style.mark.text_color_rgb());
 
         // Close any open section so the first line of this block
         // starts with a fresh BT (and absolute Td). Subsequent lines
@@ -2793,12 +2814,17 @@ impl<'a> Engine<'a> {
                         }
                         cursor_needs_reset = false;
                     }
-                    // Restore the text fill colour if this is a link
-                    // (link colour) vs body (block colour).
+                    // Restore the text fill colour: link colour for a
+                    // link, `[mark]` colour for a highlight, otherwise
+                    // the block colour.
                     if seg.link.is_some() {
                         if let Some(lc) = link_color.clone() {
                             self.page_ops.push(Op::SetFillColor { col: lc });
                         }
+                    } else if seg.flags.highlight {
+                        self.page_ops.push(Op::SetFillColor {
+                            col: mark_color.clone(),
+                        });
                     } else if let Some(c) = color.clone() {
                         self.page_ops.push(Op::SetFillColor { col: c });
                     }

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -140,6 +140,10 @@ struct Engine<'a> {
     /// Highlight rects collected while the current text section is
     /// open; drained into `page_ops` when it closes.
     pending_highlights: Vec<HighlightBox>,
+    /// True while rendering a fenced code block, so monospace runs
+    /// keep the `[code_block]` colour instead of being repainted with
+    /// the `[code_inline]` colour (both carry the `monospace` flag).
+    in_code_block: bool,
     /// Stack of block backgrounds currently open (LIFO — matches the
     /// nesting of `begin_block` / `end_block`). When a page break
     /// happens mid-block, [`start_new_page`] paints the fragment that
@@ -205,6 +209,7 @@ impl<'a> Engine<'a> {
             in_text_section: false,
             text_section_marker: 0,
             pending_highlights: Vec::new(),
+            in_code_block: false,
             open_bg: Vec::new(),
             math: None,
             math_inline_cache: HashMap::new(),
@@ -2463,6 +2468,7 @@ impl<'a> Engine<'a> {
         let color = Some(rgb_color(s.text_color_rgb()));
         let base = base_flags_from_block(&s).with_monospace();
         let ctx = self.begin_block(&s);
+        self.in_code_block = true;
         for line in lines {
             let run = InlineRun { math: None,
                 text: line.clone(),
@@ -2477,6 +2483,7 @@ impl<'a> Engine<'a> {
                 color.clone(),
             );
         }
+        self.in_code_block = false;
         self.end_block(ctx);
     }
 
@@ -2625,6 +2632,7 @@ impl<'a> Engine<'a> {
 
         let link_color = Some(rgb_color(self.style.link.text_color_rgb()));
         let mark_color = rgb_color(self.style.mark.text_color_rgb());
+        let code_inline_color = rgb_color(self.style.code_inline.text_color_rgb());
 
         // Close any open section so the first line of this block
         // starts with a fresh BT (and absolute Td). Subsequent lines
@@ -2815,8 +2823,8 @@ impl<'a> Engine<'a> {
                         cursor_needs_reset = false;
                     }
                     // Restore the text fill colour: link colour for a
-                    // link, `[mark]` colour for a highlight, otherwise
-                    // the block colour.
+                    // link, `[mark]` colour for a highlight, `[code_inline]`
+                    // colour for inline code, otherwise the block colour.
                     if seg.link.is_some() {
                         if let Some(lc) = link_color.clone() {
                             self.page_ops.push(Op::SetFillColor { col: lc });
@@ -2824,6 +2832,10 @@ impl<'a> Engine<'a> {
                     } else if seg.flags.highlight {
                         self.page_ops.push(Op::SetFillColor {
                             col: mark_color.clone(),
+                        });
+                    } else if seg.flags.monospace && !self.in_code_block {
+                        self.page_ops.push(Op::SetFillColor {
+                            col: code_inline_color.clone(),
                         });
                     } else if let Some(c) = color.clone() {
                         self.page_ops.push(Op::SetFillColor { col: c });

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2383,18 +2383,7 @@ impl<'a> Engine<'a> {
         let idx = level.clamp(1, 6) as usize - 1;
         let s = self.style.headings[idx].clone();
         let color = Some(rgb_color(s.text_color_rgb()));
-        let base_flags = RunFlags {
-            bold: s.is_bold(),
-            italic: s.is_italic(),
-            monospace: false,
-            strikethrough: false,
-            highlight: false,
-            superscript: false,
-            subscript: false,
-            small_caps: false,
-            small: false,
-            underline: false,
-        };
+        let base_flags = base_flags_from_block(&s);
 
         let text = collect_heading_text(runs);
         let base_slug = {
@@ -2435,7 +2424,7 @@ impl<'a> Engine<'a> {
     fn render_paragraph(&mut self, runs: &[InlineRun]) {
         let s = self.style.paragraph.clone();
         let color = Some(rgb_color(s.text_color_rgb()));
-        let base = RunFlags::default();
+        let base = base_flags_from_block(&s);
         let ctx = self.begin_block(&s);
         let owned_runs;
         let runs_ref: &[InlineRun] = if s.small_caps {
@@ -2453,7 +2442,7 @@ impl<'a> Engine<'a> {
     fn render_code_block(&mut self, lines: &[String]) {
         let s = self.style.code_block.clone();
         let color = Some(rgb_color(s.text_color_rgb()));
-        let base = RunFlags::default().with_monospace();
+        let base = base_flags_from_block(&s).with_monospace();
         let ctx = self.begin_block(&s);
         for line in lines {
             let run = InlineRun { math: None,
@@ -3735,6 +3724,20 @@ fn pt_to_mm(pt: f32) -> f32 {
     pt / MM_TO_PT
 }
 
+
+/// Block-level style → base run flags. Weight, slant, and the
+/// underline / strikethrough decorations are set on the style block
+/// rather than by inline markup, so they have to be folded into the
+/// base flags that `write_wrapped_runs` applies to every run.
+fn base_flags_from_block(s: &ResolvedBlock) -> RunFlags {
+    RunFlags {
+        bold: s.is_bold(),
+        italic: s.is_italic(),
+        underline: s.underline,
+        strikethrough: s.strikethrough,
+        ..RunFlags::default()
+    }
+}
 
 /// Concatenate the plain text of a heading's inline runs. The PDF
 /// outline + slug source. Markdown emphasis / inline code inside a

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2113,8 +2113,6 @@ impl<'a> Engine<'a> {
     }
 
     fn render_list(&mut self, entries: &[ListEntry]) {
-        const BULLET_GAP_MM: f32 = 2.0;
-        let bullet_gap_pt = mm_to_pt(BULLET_GAP_MM);
         let saved_left = self.indent_left_pt;
 
         // CommonMark §5.3: the whole list is loose if any item is loose.
@@ -2230,7 +2228,7 @@ impl<'a> Engine<'a> {
                 }
             }
 
-            self.indent_left_pt = (saved_left + bullet_width + bullet_gap_pt)
+            self.indent_left_pt = (saved_left + bullet_width + list_style.bullet_gap_pt)
                 .min(self.indent_right_pt - 10.0);
 
             self.write_wrapped_runs(
@@ -2521,7 +2519,7 @@ impl<'a> Engine<'a> {
         runs: &[InlineRun],
         font_size: f32,
         line_height_mult: f32,
-        _base_flags: RunFlags,
+        base_flags: RunFlags,
         color: Option<Color>,
     ) {
         if runs.is_empty() {
@@ -2529,6 +2527,23 @@ impl<'a> Engine<'a> {
         }
         let size_pt = font_size;
         let line_height_pt = size_pt * line_height_mult.max(0.5);
+
+        // Fold the block-level base style (e.g. a heading's bold
+        // weight) into every run so it isn't lost when a run carries
+        // its own inline flags. A default `base_flags` is a no-op.
+        let merged_runs;
+        let runs: &[InlineRun] = if base_flags == RunFlags::default() {
+            runs
+        } else {
+            merged_runs = runs
+                .iter()
+                .map(|r| InlineRun {
+                    flags: r.flags.or(base_flags),
+                    ..r.clone()
+                })
+                .collect::<Vec<_>>();
+            &merged_runs
+        };
 
         // Split runs into a flat sequence of (word, flags) pairs.
         // Whitespace is the only break opportunity in this phase.

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2807,7 +2807,7 @@ impl<'a> Engine<'a> {
                     }
                     // Restore the text fill colour if this is a link
                     // (link colour) vs body (block colour).
-                    if seg.flags.underline {
+                    if seg.link.is_some() {
                         if let Some(lc) = link_color.clone() {
                             self.page_ops.push(Op::SetFillColor { col: lc });
                         }
@@ -2826,6 +2826,9 @@ impl<'a> Engine<'a> {
                 // Buffer decorations and link rects until the line is
                 // finished — they need a closed text section to draw
                 // paths on top.
+                // A link is underlined only when `[link].underline`
+                // is set; `<u>` text always is.
+                let link_underline = seg.link.is_some() && self.style.link.underline;
                 if seg.flags.underline || seg.flags.strikethrough || seg.link.is_some() {
                     let decoration_y_pt = if seg.flags.strikethrough {
                         baseline_y_pt - size_pt * 0.30
@@ -2835,7 +2838,7 @@ impl<'a> Engine<'a> {
                     self.pending_decorations.push(PendingDecoration {
                         kind: if seg.flags.strikethrough {
                             DecorationKind::Strike
-                        } else if seg.flags.underline {
+                        } else if seg.flags.underline || link_underline {
                             DecorationKind::Underline
                         } else {
                             DecorationKind::None

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -491,21 +491,10 @@ impl<'a> Engine<'a> {
         self.close_text_section();
         self.ensure_text_section();
         self.move_cursor_to(center_x, baseline_y);
-        self.page_ops.push(Op::SetFont {
-            font: self.font_set.handle(flags),
-            size: Pt(size_pt),
-        });
         self.page_ops.push(Op::SetFillColor {
             col: rgb_color(style.text_color_rgb()),
         });
-        let emit = if self.font_set.needs_transliteration(flags) {
-            to_win1252(text)
-        } else {
-            text.to_string()
-        };
-        self.page_ops.push(Op::ShowText {
-            items: vec![TextItem::Text(emit)],
-        });
+        emit_text_chunks(&mut self.page_ops, self.font_set, flags, text, size_pt);
         self.close_text_section();
 
         self.advance_y(size_pt);
@@ -620,21 +609,16 @@ impl<'a> Engine<'a> {
         self.close_text_section();
         self.ensure_text_section();
         self.move_cursor_to(row_left, baseline_y);
-        self.page_ops.push(Op::SetFont {
-            font: self.font_set.handle(flags),
-            size: Pt(size_pt),
-        });
         self.page_ops.push(Op::SetFillColor {
             col: rgb_color(style.text_color_rgb()),
         });
-        let text_to_emit = if self.font_set.needs_transliteration(flags) {
-            to_win1252(&anchor.text)
-        } else {
-            anchor.text.clone()
-        };
-        self.page_ops.push(Op::ShowText {
-            items: vec![TextItem::Text(text_to_emit)],
-        });
+        emit_text_chunks(
+            &mut self.page_ops,
+            self.font_set,
+            flags,
+            &anchor.text,
+            size_pt,
+        );
 
         // Page-number portion (right-aligned at row_right).
         let page_str = page_num.to_string();
@@ -643,18 +627,13 @@ impl<'a> Engine<'a> {
         self.close_text_section();
         self.ensure_text_section();
         self.move_cursor_to(num_x, baseline_y);
-        self.page_ops.push(Op::SetFont {
-            font: self.font_set.handle(flags),
-            size: Pt(size_pt),
-        });
-        let num_emit = if self.font_set.needs_transliteration(flags) {
-            to_win1252(&page_str)
-        } else {
-            page_str
-        };
-        self.page_ops.push(Op::ShowText {
-            items: vec![TextItem::Text(num_emit)],
-        });
+        emit_text_chunks(
+            &mut self.page_ops,
+            self.font_set,
+            flags,
+            &page_str,
+            size_pt,
+        );
         self.close_text_section();
 
         // Clickable rect spans the whole row.
@@ -1155,27 +1134,16 @@ impl<'a> Engine<'a> {
 
         let x_mm = pt_to_mm(x_pt);
         let y_mm = pt_to_mm(self.page_height_pt() - y_pt);
-        let emit = if self.font_set.needs_transliteration(flags) {
-            to_win1252(text)
-        } else {
-            text.to_string()
-        };
 
         ops.push(Op::SaveGraphicsState);
         ops.push(Op::StartTextSection);
         ops.push(Op::SetTextCursor {
             pos: Point::new(Mm(x_mm), Mm(y_mm)),
         });
-        ops.push(Op::SetFont {
-            font: self.font_set.handle(flags),
-            size: Pt(size_pt),
-        });
         ops.push(Op::SetFillColor {
             col: rgb_color(style.text_color_rgb()),
         });
-        ops.push(Op::ShowText {
-            items: vec![TextItem::Text(emit)],
-        });
+        emit_text_chunks(ops, self.font_set, flags, text, size_pt);
         ops.push(Op::EndTextSection);
         ops.push(Op::RestoreGraphicsState);
     }
@@ -2248,22 +2216,17 @@ impl<'a> Engine<'a> {
                     self.close_text_section();
                     self.ensure_text_section();
                     self.move_cursor_to(bullet_x, bullet_y);
-                    self.page_ops.push(Op::SetFont {
-                        font: self.font_set.handle(bullet_flags),
-                        size: Pt(size_pt),
-                    });
                     self.page_ops.push(Op::SetLineHeight {
                         lh: Pt(size_pt * line_height.max(0.5)),
                     });
                     self.page_ops.push(Op::SetFillColor { col: bullet_col });
-                    let bullet_emit = if needs_xlit {
-                        to_win1252(&bullet_text)
-                    } else {
-                        bullet_text.clone()
-                    };
-                    self.page_ops.push(Op::ShowText {
-                        items: vec![TextItem::Text(bullet_emit)],
-                    });
+                    emit_text_chunks(
+                        &mut self.page_ops,
+                        self.font_set,
+                        bullet_flags,
+                        &bullet_text,
+                        size_pt,
+                    );
                 }
             }
 
@@ -2777,13 +2740,6 @@ impl<'a> Engine<'a> {
                     (size_pt, baseline_y_pt)
                 };
                 let seg_width = self.font_set.measure(seg.flags, &seg.text, seg_size);
-                let font_handle = self.font_set.handle(seg.flags);
-                let needs_trans = self.font_set.needs_transliteration(seg.flags);
-                let emit_text = if needs_trans {
-                    to_win1252(&seg.text)
-                } else {
-                    seg.text.clone()
-                };
 
                 if seg.flags.superscript || seg.flags.subscript {
                     // Close the line's main section, emit the small
@@ -2798,16 +2754,16 @@ impl<'a> Engine<'a> {
                     self.page_ops.push(Op::SetTextCursor {
                         pos: Point::new(Mm(x_mm), Mm(y_mm)),
                     });
-                    self.page_ops.push(Op::SetFont {
-                        font: font_handle,
-                        size: Pt(seg_size),
-                    });
                     if let Some(c) = color.clone() {
                         self.page_ops.push(Op::SetFillColor { col: c });
                     }
-                    self.page_ops.push(Op::ShowText {
-                        items: vec![TextItem::Text(emit_text)],
-                    });
+                    emit_text_chunks(
+                        &mut self.page_ops,
+                        self.font_set,
+                        seg.flags,
+                        &seg.text,
+                        seg_size,
+                    );
                     self.page_ops.push(Op::EndTextSection);
                     self.page_ops.push(Op::RestoreGraphicsState);
                     cursor_needs_reset = true;
@@ -2843,13 +2799,13 @@ impl<'a> Engine<'a> {
                     } else if let Some(c) = color.clone() {
                         self.page_ops.push(Op::SetFillColor { col: c });
                     }
-                    self.page_ops.push(Op::SetFont {
-                        font: font_handle,
-                        size: Pt(seg_size),
-                    });
-                    self.page_ops.push(Op::ShowText {
-                        items: vec![TextItem::Text(emit_text)],
-                    });
+                    emit_text_chunks(
+                        &mut self.page_ops,
+                        self.font_set,
+                        seg.flags,
+                        &seg.text,
+                        seg_size,
+                    );
                 }
 
                 // Buffer decorations and link rects until the line is
@@ -3047,6 +3003,36 @@ struct HighlightBox {
     x1_pt: f32,
     baseline_y_pt: f32,
     size_pt: f32,
+}
+
+/// Emit `text` at `size_pt` using the run flags' resolved font chain.
+/// When the FontSet has no fallbacks, this produces exactly one
+/// `SetFont` + `ShowText` pair — identical to the pre-fallback emit
+/// path. When fallbacks are loaded, the text is split into per-font
+/// chunks ([`FontSet::split_for_emit`]) and one `SetFont` + `ShowText`
+/// pair is emitted per chunk, so codepoints uncovered by the primary
+/// render in their first covering fallback.
+fn emit_text_chunks(
+    ops: &mut Vec<Op>,
+    font_set: &FontSet,
+    flags: RunFlags,
+    text: &str,
+    size_pt: f32,
+) {
+    for chunk in font_set.split_for_emit(flags, text, size_pt) {
+        ops.push(Op::SetFont {
+            font: chunk.handle,
+            size: Pt(size_pt),
+        });
+        let emit = if chunk.needs_transliteration {
+            to_win1252(&chunk.text)
+        } else {
+            chunk.text
+        };
+        ops.push(Op::ShowText {
+            items: vec![TextItem::Text(emit)],
+        });
+    }
 }
 
 /// Convert a UTF-8 string to ASCII for safe rendering with

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -151,6 +151,10 @@ struct Engine<'a> {
     /// fields (margins, padding, border, background) stay paragraph's,
     /// since the container already draws its own box.
     text_style_override: Option<ResolvedBlock>,
+    /// First-line indent (points) for the next `write_wrapped_runs`
+    /// call. Set by `render_paragraph` from `[paragraph].indent_pt`;
+    /// the call consumes it (resets to 0) so it applies once.
+    first_line_indent_pt: f32,
     /// Stack of block backgrounds currently open (LIFO — matches the
     /// nesting of `begin_block` / `end_block`). When a page break
     /// happens mid-block, [`start_new_page`] paints the fragment that
@@ -218,6 +222,7 @@ impl<'a> Engine<'a> {
             pending_highlights: Vec::new(),
             in_code_block: false,
             text_style_override: None,
+            first_line_indent_pt: 0.0,
             open_bg: Vec::new(),
             math: None,
             math_inline_cache: HashMap::new(),
@@ -940,9 +945,6 @@ impl<'a> Engine<'a> {
             return;
         }
         let boxes = std::mem::take(&mut self.pending_highlights);
-        let Some(fill_rgb) = self.style.mark.background_color_rgb() else {
-            return;
-        };
         let page_h_pt = self.page_height_pt();
         let mut bg_ops: Vec<Op> = Vec::new();
         for b in &boxes {
@@ -952,7 +954,7 @@ impl<'a> Engine<'a> {
                 b.baseline_y_pt - b.size_pt * 0.80,
                 b.x1_pt,
                 b.baseline_y_pt + b.size_pt * 0.20,
-                rgb_color(fill_rgb),
+                b.fill.clone(),
                 page_h_pt,
             );
         }
@@ -2488,6 +2490,7 @@ impl<'a> Engine<'a> {
             runs
         };
         self.current_text_align = s.text_align;
+        self.first_line_indent_pt = s.indent_pt;
         self.write_wrapped_runs(runs_ref, s.font_size_pt, s.line_height, base, color);
         self.current_text_align = TextAlignment::Left;
         self.end_block(ctx);
@@ -2574,6 +2577,9 @@ impl<'a> Engine<'a> {
         }
         let size_pt = font_size;
         let line_height_pt = size_pt * line_height_mult.max(0.5);
+        // First-line indent applies once; consume it so nested calls
+        // (e.g. list children) don't inherit it.
+        let first_line_indent_pt = std::mem::take(&mut self.first_line_indent_pt);
 
         // Fold the block-level base style (e.g. a heading's bold
         // weight) into every run so it isn't lost when a run carries
@@ -2617,9 +2623,15 @@ impl<'a> Engine<'a> {
                 None => self.font_set.measure(word.flags, &word.text, size_pt),
             };
 
+            // The first line is narrowed by the first-line indent.
+            let line_limit = if lines.is_empty() {
+                max_width - first_line_indent_pt
+            } else {
+                max_width
+            };
             // If the very first piece of a line is wider than the
             // page, push it anyway — we don't break inside a word.
-            if !current.is_empty() && current_width + word_width > max_width {
+            if !current.is_empty() && current_width + word_width > line_limit {
                 lines.push(std::mem::take(&mut current));
                 current_width = 0.0;
                 // Drop any leading whitespace on the new line.
@@ -2713,15 +2725,18 @@ impl<'a> Engine<'a> {
                     space_count += 1;
                 }
             }
-            let slack_pt = (max_width - natural_w_pt).max(0.0);
+            // The first line is shifted right and narrowed by the
+            // first-line indent; later lines use the full column.
+            let line_indent = if line_idx == 0 { first_line_indent_pt } else { 0.0 };
+            let eff_left = self.indent_left_pt + line_indent;
+            let eff_max_width = (max_width - line_indent).max(0.0);
+            let slack_pt = (eff_max_width - natural_w_pt).max(0.0);
             let is_last_line = line_idx == last_line_idx;
 
             let (line_x_start, word_spacing_pt) = match align {
-                TextAlignment::Left => (self.indent_left_pt, 0.0),
-                TextAlignment::Center => {
-                    (self.indent_left_pt + slack_pt * 0.5, 0.0)
-                }
-                TextAlignment::Right => (self.indent_left_pt + slack_pt, 0.0),
+                TextAlignment::Left => (eff_left, 0.0),
+                TextAlignment::Center => (eff_left + slack_pt * 0.5, 0.0),
+                TextAlignment::Right => (eff_left + slack_pt, 0.0),
                 TextAlignment::Justify => {
                     // Don't justify the last line of a paragraph, lines
                     // with no break opportunities, or lines whose slack
@@ -2730,13 +2745,13 @@ impl<'a> Engine<'a> {
                     // short word).
                     let stretch_ok = space_count > 0
                         && slack_pt > 0.0
-                        && slack_pt < max_width * 0.30;
+                        && slack_pt < eff_max_width * 0.30;
                     let tw = if !is_last_line && stretch_ok {
                         (slack_pt / space_count as f32).min(size_pt * 0.5)
                     } else {
                         0.0
                     };
-                    (self.indent_left_pt, tw)
+                    (eff_left, tw)
                 }
             };
             let needs_absolute_td = !matches!(
@@ -2909,12 +2924,22 @@ impl<'a> Engine<'a> {
                         baseline_y_pt,
                     });
                 }
-                if seg.flags.highlight {
+                // Inline background box: `[mark]` fill for a highlight,
+                // `[code_inline]` fill for inline code (not code blocks).
+                let inline_bg = if seg.flags.highlight {
+                    self.style.mark.background_color_rgb()
+                } else if seg.flags.monospace && !self.in_code_block {
+                    self.style.code_inline.background_color_rgb()
+                } else {
+                    None
+                };
+                if let Some(rgb) = inline_bg {
                     self.pending_highlights.push(HighlightBox {
                         x0_pt: x_cursor_pt,
                         x1_pt: x_cursor_pt + seg_width,
                         baseline_y_pt,
                         size_pt,
+                        fill: rgb_color(rgb),
                     });
                 }
                 x_cursor_pt += seg_width;
@@ -3070,15 +3095,17 @@ struct PendingDecoration {
     baseline_y_pt: f32,
 }
 
-/// One `==highlight==` segment's box, in top-down points. Collected
-/// while a text section is open and painted (under the glyphs) when
-/// the section closes.
+/// One inline background box (a `==highlight==` span or inline-code
+/// span), in top-down points. Collected while a text section is open
+/// and painted — with its own `fill` — under the glyphs when the
+/// section closes.
 #[derive(Debug)]
 struct HighlightBox {
     x0_pt: f32,
     x1_pt: f32,
     baseline_y_pt: f32,
     size_pt: f32,
+    fill: Color,
 }
 
 /// Emit `text` at `size_pt` using the run flags' resolved font chain.

--- a/src/lib/render/layout.rs
+++ b/src/lib/render/layout.rs
@@ -2262,8 +2262,9 @@ impl<'a> Engine<'a> {
                 }
             }
 
-            self.indent_left_pt = (saved_left + bullet_width + list_style.bullet_gap_pt)
+            let text_indent = (saved_left + bullet_width + list_style.bullet_gap_pt)
                 .min(self.indent_right_pt - 10.0);
+            self.indent_left_pt = text_indent;
 
             self.write_wrapped_runs(
                 &entry.runs,
@@ -2273,7 +2274,17 @@ impl<'a> Engine<'a> {
                 Some(rgb_color(s.text_color_rgb())),
             );
 
+            // A nested list steps in by `indent_per_level_pt` from this
+            // list's bullet column; an item's other children (e.g.
+            // continuation paragraphs) stay aligned with the item text.
+            let nested_indent = (saved_left + list_style.indent_per_level_pt)
+                .min(self.indent_right_pt - 10.0);
             for child in &entry.children {
+                self.indent_left_pt = if matches!(child, Block::List { .. }) {
+                    nested_indent
+                } else {
+                    text_indent
+                };
                 self.render_block(child);
             }
 

--- a/src/lib/render/lower.rs
+++ b/src/lib/render/lower.rs
@@ -906,14 +906,13 @@ fn flatten_one(
             ));
         }
         Token::Link { content, url, .. } => {
-            // The link styling (underline + color) is applied at the
-            // layout pass — here we just propagate the URL and mark
-            // the run with underline so the visual decoration is
-            // ready before the annotation is drawn.
+            // Link styling (underline + colour) is applied at the
+            // layout pass from the `[link]` config — the run only
+            // carries the URL. The underline flag is *not* forced
+            // here, so `[link].underline = false` is honoured.
             let url_str = url.as_str();
-            let nested = flags.with_underline();
             for t in content {
-                flatten_one(t, nested, Some(url_str), out, footnotes);
+                flatten_one(t, flags, Some(url_str), out, footnotes);
             }
         }
         Token::FootnoteReference(label) => {

--- a/src/lib/render/lower.rs
+++ b/src/lib/render/lower.rs
@@ -842,7 +842,7 @@ impl InlineHtmlDepth {
             flags = flags.with_small();
         }
         if self.kbd > 0 {
-            flags = flags.with_monospace();
+            flags = flags.with_inline_code();
         }
         flags
     }
@@ -890,7 +890,7 @@ fn flatten_one(
             block: false,
             ..
         } => {
-            let mono = flags.with_monospace();
+            let mono = flags.with_inline_code();
             push_text(out, content, mono, link);
         }
         Token::Math { content, .. } => {

--- a/src/lib/render/mod.rs
+++ b/src/lib/render/mod.rs
@@ -127,7 +127,20 @@ pub fn render_to_bytes(
     };
 
     let blocks = lower::lower(&tokens);
-    let usage = ir::VariantUsage::analyze(&blocks);
+    let mut usage = ir::VariantUsage::analyze(&blocks);
+    // Headings and blockquotes get their weight / slant from the
+    // theme, not from per-run flags, so the IR walk above can't see
+    // them. Without this, an external font would skip loading the
+    // bold (or italic) face and these blocks would render regular.
+    for block_style in style.headings.iter().chain([&style.blockquote]) {
+        if block_style.is_bold() && block_style.is_italic() {
+            usage.body_bold_italic = true;
+        } else if block_style.is_bold() {
+            usage.body_bold = true;
+        } else if block_style.is_italic() {
+            usage.body_italic = true;
+        }
+    }
     let font_set = font::FontSet::load_with_style_fallbacks(
         font_config,
         &style.fallback_fonts,

--- a/src/lib/render/mod.rs
+++ b/src/lib/render/mod.rs
@@ -141,9 +141,30 @@ pub fn render_to_bytes(
             usage.body_italic = true;
         }
     }
+    let cb = &style.code_block;
+    if cb.is_bold() && cb.is_italic() {
+        usage.mono_bold_italic = true;
+    } else if cb.is_bold() {
+        usage.mono_bold = true;
+    } else if cb.is_italic() {
+        usage.mono_italic = true;
+    }
+    // Load a distinct inline-code family only when `[code_inline]
+    // font_family` is set AND differs from `[code_block] font_family`.
+    // Otherwise inline and block code share the same path (so the
+    // default theme, which spells both `"Courier"`, stays byte-
+    // identical to the pre-feature output).
+    let code_inline_font = match (
+        style.code_inline.font_family.as_deref(),
+        style.code_block.font_family.as_deref(),
+    ) {
+        (Some(ci), Some(cb)) if ci.eq_ignore_ascii_case(cb) => None,
+        (ci, _) => ci,
+    };
     let font_set = font::FontSet::load_with_style_fallbacks(
         font_config,
         &style.fallback_fonts,
+        code_inline_font,
         &used_codepoints,
         usage,
         &mut doc,

--- a/src/lib/render/mod.rs
+++ b/src/lib/render/mod.rs
@@ -128,7 +128,13 @@ pub fn render_to_bytes(
 
     let blocks = lower::lower(&tokens);
     let usage = ir::VariantUsage::analyze(&blocks);
-    let font_set = font::FontSet::load(font_config, &used_codepoints, usage, &mut doc);
+    let font_set = font::FontSet::load_with_style_fallbacks(
+        font_config,
+        &style.fallback_fonts,
+        &used_codepoints,
+        usage,
+        &mut doc,
+    );
     let pages = layout::lay_out_pages(&blocks, &style, &font_set, &mut doc);
 
     let (fallback_w, fallback_h) = layout::page_dimensions_mm(&style.page);

--- a/src/lib/styling/merge.rs
+++ b/src/lib/styling/merge.rs
@@ -143,6 +143,7 @@ fn merge_block(base: BlockConfig, overlay: BlockConfig) -> BlockConfig {
         strikethrough: overlay.strikethrough.or(base.strikethrough),
         underline: overlay.underline.or(base.underline),
         small_caps: overlay.small_caps.or(base.small_caps),
+        fallback_fonts: overlay.fallback_fonts.or(base.fallback_fonts),
     }
 }
 
@@ -385,6 +386,7 @@ fn lower(theme: &str, cfg: DocumentConfig) -> Result<ResolvedStyle, ResolveError
     let footer = lower_furniture(theme, "footer", &defaults, cfg.footer)?;
     let title_page = lower_title_page(theme, &defaults, cfg.title_page)?;
     let toc = lower_toc(theme, &defaults, cfg.toc)?;
+    let fallback_fonts = defaults.fallback_fonts.clone().unwrap_or_default();
 
     Ok(ResolvedStyle {
         page,
@@ -408,6 +410,7 @@ fn lower(theme: &str, cfg: DocumentConfig) -> Result<ResolvedStyle, ResolveError
         footer,
         title_page,
         toc,
+        fallback_fonts,
     })
 }
 

--- a/src/lib/styling/merge.rs
+++ b/src/lib/styling/merge.rs
@@ -188,6 +188,7 @@ fn merge_list_style(base: ListStyleConfig, overlay: ListStyleConfig) -> ListStyl
         indent_per_level_pt: overlay.indent_per_level_pt.or(base.indent_per_level_pt),
         item_spacing_tight_pt: overlay.item_spacing_tight_pt.or(base.item_spacing_tight_pt),
         item_spacing_loose_pt: overlay.item_spacing_loose_pt.or(base.item_spacing_loose_pt),
+        bullet_gap_pt: overlay.bullet_gap_pt.or(base.bullet_gap_pt),
     }
 }
 
@@ -624,6 +625,10 @@ fn lower_list(
             .item_spacing_loose_pt
             .or(common.item_spacing_loose_pt)
             .unwrap_or(2.0),
+        bullet_gap_pt: raw
+            .bullet_gap_pt
+            .or(common.bullet_gap_pt)
+            .unwrap_or(5.67),
     })
 }
 

--- a/src/lib/styling/merge.rs
+++ b/src/lib/styling/merge.rs
@@ -346,6 +346,12 @@ fn lower(theme: &str, cfg: DocumentConfig) -> Result<ResolvedStyle, ResolveError
         align: image_cfg.align.unwrap_or(ImageAlign::Center),
         margin_before_pt: image_cfg.margin_before_pt.unwrap_or(0.0),
         margin_after_pt: image_cfg.margin_after_pt.unwrap_or(0.0),
+        caption: lower_block(
+            theme,
+            "image.caption",
+            &defaults,
+            image_cfg.caption.unwrap_or_default(),
+        )?,
     };
 
     let rule_cfg = cfg.horizontal_rule.unwrap_or_default();

--- a/src/lib/styling/resolved.rs
+++ b/src/lib/styling/resolved.rs
@@ -113,13 +113,15 @@ pub struct ResolvedTable {
     pub margin_after_pt: f32,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ResolvedImage {
     pub max_width_pct: f32,
     pub align: ImageAlign,
     pub margin_before_pt: f32,
     pub margin_after_pt: f32,
+    /// Styling for the caption line drawn under an image.
+    pub caption: ResolvedBlock,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/src/lib/styling/resolved.rs
+++ b/src/lib/styling/resolved.rs
@@ -36,6 +36,11 @@ pub struct ResolvedStyle {
     pub footer: Option<ResolvedPageFurniture>,
     pub title_page: Option<ResolvedTitlePage>,
     pub toc: Option<ResolvedToc>,
+    /// Ordered list of fallback font names (resolved from
+    /// `[defaults].fallback_fonts`). The renderer consults these in
+    /// order when the primary body / code font lacks a glyph for a
+    /// codepoint.
+    pub fallback_fonts: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/src/lib/styling/resolved.rs
+++ b/src/lib/styling/resolved.rs
@@ -97,6 +97,7 @@ pub struct ResolvedList {
     pub indent_per_level_pt: f32,
     pub item_spacing_tight_pt: f32,
     pub item_spacing_loose_pt: f32,
+    pub bullet_gap_pt: f32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/lib/styling/schema.rs
+++ b/src/lib/styling/schema.rs
@@ -100,6 +100,12 @@ pub struct BlockConfig {
     /// OpenType `smcp` substitution depends on the loaded font and is
     /// a follow-up.
     pub small_caps: Option<bool>,
+    /// Ordered list of fallback font names. Codepoints not covered by
+    /// the primary body / code font are looked up in each fallback in
+    /// turn; the first font that has a glyph wins. Only the value on
+    /// the document `[defaults]` block is read by the renderer — the
+    /// field is accepted syntactically on per-block tables but ignored.
+    pub fallback_fonts: Option<Vec<String>>,
 }
 
 /// Subset of `BlockConfig` for true inline runs (`code_inline`,

--- a/src/lib/styling/schema.rs
+++ b/src/lib/styling/schema.rs
@@ -182,6 +182,8 @@ pub struct ListStyleConfig {
     pub item_spacing_tight_pt: Option<f32>,
     /// Spacing between items in a loose list (blank line between items).
     pub item_spacing_loose_pt: Option<f32>,
+    /// Horizontal gap between the bullet/number and the item text.
+    pub bullet_gap_pt: Option<f32>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]

--- a/src/lib/styling/themes/default.toml
+++ b/src/lib/styling/themes/default.toml
@@ -130,6 +130,7 @@ margin_after_pt = 0.5
 indent_per_level_pt = 17.0  # ~6 mm
 item_spacing_tight_pt = 0.5
 item_spacing_loose_pt = 6.0
+bullet_gap_pt = 5.67  # ~2 mm gap between bullet and item text
 
 [list.unordered]
 bullet = "•"

--- a/src/lib/validation.rs
+++ b/src/lib/validation.rs
@@ -87,10 +87,16 @@ impl std::fmt::Display for ValidationWarning {
     }
 }
 
-/// Validates markdown content and configuration, returning warnings
+/// Validates markdown content and configuration, returning warnings.
+///
+/// `style_fallback_fonts` is the resolved `[defaults].fallback_fonts`
+/// list from the styling config (empty when no TOML config or no
+/// fallbacks set). When non-empty, the Unicode-without-font warning is
+/// suppressed — fallbacks cover the codepoints the primary doesn't.
 pub fn validate_conversion(
     markdown: &str,
     font_config: Option<&FontConfig>,
+    style_fallback_fonts: &[String],
     output_path: Option<&str>,
 ) -> Vec<ValidationWarning> {
     let mut warnings = Vec::new();
@@ -102,7 +108,7 @@ pub fn validate_conversion(
 
     // Check for Unicode characters without appropriate font
     if let Some(unicode_chars) = detect_unicode_chars(markdown) {
-        if !has_unicode_font(font_config) {
+        if !has_unicode_font(font_config, style_fallback_fonts) {
             warnings.push(ValidationWarning::unicode_without_font(unicode_chars));
         }
     }
@@ -148,14 +154,21 @@ fn detect_unicode_chars(markdown: &str) -> Option<Vec<char>> {
 ///
 /// Any external `default_font` (specified by name OR by explicit file
 /// source) takes the renderer's Identity-H Unicode emit path regardless
-/// of the font's name, so we only flag the built-in-fonts case — when
-/// nothing at all is specified, the renderer falls back to printpdf's
-/// Helvetica/Courier (WinAnsi-encoded, no Unicode).
-fn has_unicode_font(font_config: Option<&FontConfig>) -> bool {
+/// of the font's name. Configured fallback fonts (either on
+/// `FontConfig` or via `[defaults].fallback_fonts` in TOML) also count:
+/// uncovered codepoints route to them via the renderer's split path,
+/// so the document is not stuck on the Win-Ansi-only built-in path.
+fn has_unicode_font(font_config: Option<&FontConfig>, style_fallback_fonts: &[String]) -> bool {
+    if !style_fallback_fonts.is_empty() {
+        return true;
+    }
     let Some(config) = font_config else {
         return false;
     };
-    config.default_font.is_some() || config.default_font_source.is_some()
+    config.default_font.is_some()
+        || config.default_font_source.is_some()
+        || !config.fallback_fonts.is_empty()
+        || !config.fallback_font_sources.is_empty()
 }
 
 /// Checks for common markdown syntax issues
@@ -375,7 +388,7 @@ mod tests {
     #[test]
     fn test_large_document_warning() {
         let large_text = "a".repeat(200_000);
-        let warnings = validate_conversion(&large_text, None, None);
+        let warnings = validate_conversion(&large_text, None, &[], None);
         assert!(warnings
             .iter()
             .any(|w| w.kind == WarningKind::LargeDocument));
@@ -390,9 +403,11 @@ mod tests {
             default_font_source: None,
             code_font: None,
             code_font_source: None,
+            fallback_fonts: Vec::new(),
+            fallback_font_sources: Vec::new(),
             enable_subsetting: true,
         };
-        let warnings = validate_conversion("Hello café", Some(&cfg), None);
+        let warnings = validate_conversion("Hello café", Some(&cfg), &[], None);
         assert!(
             warnings
                 .iter()
@@ -405,9 +420,38 @@ mod tests {
     fn missing_font_config_still_warns_about_unicode() {
         // No font specified → renderer falls back to built-in
         // WinAnsi-encoded Helvetica/Courier; warning still fires.
-        let warnings = validate_conversion("Hello café", None, None);
+        let warnings = validate_conversion("Hello café", None, &[], None);
         assert!(warnings
             .iter()
             .any(|w| w.kind == WarningKind::UnicodeWithoutFont));
+    }
+
+    #[test]
+    fn style_fallback_fonts_suppress_unicode_warning() {
+        // `[defaults].fallback_fonts = ["..."]` from the TOML config
+        // is a valid Unicode strategy: uncovered codepoints route to
+        // the configured fallbacks. No warning expected.
+        let style_fallbacks = vec!["Noto Sans CJK SC".to_string()];
+        let warnings = validate_conversion("Hello 日本語", None, &style_fallbacks, None);
+        assert!(
+            warnings
+                .iter()
+                .all(|w| w.kind != WarningKind::UnicodeWithoutFont),
+            "configured fallback_fonts should suppress the Unicode warning"
+        );
+    }
+
+    #[test]
+    fn font_config_fallback_fonts_suppress_unicode_warning() {
+        // Same property must hold when the fallback is set on the
+        // programmatic `FontConfig` rather than the TOML config.
+        let cfg = FontConfig::new().with_fallback_fonts(["Noto Sans CJK SC"]);
+        let warnings = validate_conversion("Hello 日本語", Some(&cfg), &[], None);
+        assert!(
+            warnings
+                .iter()
+                .all(|w| w.kind != WarningKind::UnicodeWithoutFont),
+            "FontConfig.fallback_fonts should suppress the Unicode warning"
+        );
     }
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -58,3 +58,9 @@ mod _showcase_inspect;
 
 #[path = "render/_admonition_showcase.rs"]
 mod _admonition_showcase;
+
+#[path = "render/_pdf_size_audit.rs"]
+mod _pdf_size_audit;
+
+#[path = "render/config_fidelity.rs"]
+mod config_fidelity;

--- a/tests/render/_pdf_size_audit.rs
+++ b/tests/render/_pdf_size_audit.rs
@@ -1,0 +1,498 @@
+//! Deep-dive PDF size auditor. Renders ~20 probe markdown snippets
+//! through the live renderer, parses each result with `lopdf`, and
+//! emits:
+//!   - decoded-stream-payload breakdown by `/Type` / `/Subtype`
+//!   - pre- vs post-compression delta (re-deflate / re-pack pass)
+//!   - actual content-stream and Form-XObject byte dumps for the
+//!     worst offenders, so byte-level patterns (float precision,
+//!     repeated operators, redundant /Resources) are visible
+//!   - multi-page resource-duplication checks (same font dict
+//!     referenced N times across pages?)
+//!
+//! Reproducible on any host: every PDF is rendered in-process from
+//! a static string. Nothing on disk is read.
+//!
+//! Opt-in:
+//!   cargo test --test render _pdf_size_audit -- --ignored --nocapture
+
+#![allow(clippy::print_stdout)]
+
+use lopdf::{Document, Object, SaveOptions};
+use markdown2pdf::config::ConfigSource;
+use markdown2pdf::parse_into_bytes;
+use std::collections::{BTreeMap, HashMap};
+
+fn probes() -> Vec<(&'static str, String)> {
+    vec![
+        ("empty", "\n".into()),
+        ("hello_world", "# Hello\n\nPlain prose.\n".into()),
+        (
+            "paragraphs+table",
+            "# Paragraphs\n\nFirst with **bold**, *italic*, `code`.\n\n> quoted\n\n| h1 | h2 |\n| -- | -- |\n| 1  | 2  |\n".into(),
+        ),
+        (
+            "link_heavy",
+            "# Links\n\nSee [a](https://example.com/a), [b](https://example.com/b), [c](https://example.com/c).\n".into(),
+        ),
+        ("link_storm", concat_links_md(20)),
+        ("math_inline", "Mass-energy: $E = mc^2$ here.\n".into()),
+        (
+            "math_display",
+            "$$\n\\int_0^\\infty \\frac{x^2}{e^x - 1} \\, dx = \\frac{2\\pi^4}{15}\n$$\n".into(),
+        ),
+        (
+            "math_repeated_glyph",
+            "$$\n1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1\n$$\n".into(),
+        ),
+        (
+            "math_same_eq_twice",
+            // Same equation rendered twice. If cross-equation glyph
+            // dedup is in place, form count should match the single-
+            // equation case; otherwise it doubles.
+            "$$ a + b = c $$\n\n$$ a + b = c $$\n".into(),
+        ),
+        (
+            "math_same_eq_x10",
+            repeat_blocks_md("$$ a + b = c $$\n\n", 10),
+        ),
+        ("math_storm", MATH_STORM.into()),
+        (
+            "code_block",
+            "```rust\nfn main() {\n    println!(\"hello\");\n}\n```\n".into(),
+        ),
+        ("hr_storm", repeat_blocks_md("---\n\nparagraph\n\n", 30)),
+        ("table_storm", TABLE_STORM.into()),
+        (
+            "admonitions_all",
+            "!!! note\n    a\n\n!!! info\n    b\n\n!!! tip\n    c\n\n!!! warning\n    d\n\n!!! danger\n    e\n".into(),
+        ),
+        ("admonitions_x10", repeat_blocks_md("!!! warning\n    body\n\n", 10)),
+        ("page_storm_10", big_doc(10)),
+        ("page_storm_50", big_doc(50)),
+        (
+            "highlight_storm",
+            "All ==highlighted== words ==need== a ==background== fill ==so== they ==accumulate== ==fast==.\n".into(),
+        ),
+    ]
+}
+
+const MATH_STORM: &str = "\
+$$ a + b = c $$
+$$ x^2 + y^2 = z^2 $$
+$$ \\sum_{i=1}^n i = \\frac{n(n+1)}{2} $$
+$$ \\int_0^1 x^2 dx = \\frac{1}{3} $$
+$$ \\frac{d}{dx} \\sin x = \\cos x $$
+$$ \\nabla \\cdot \\vec{E} = \\frac{\\rho}{\\varepsilon_0} $$
+$$ e^{i\\pi} + 1 = 0 $$
+$$ \\binom{n}{k} = \\frac{n!}{k!(n-k)!} $$
+$$ \\sqrt{2} \\approx 1.414 $$
+$$ \\lim_{n \\to \\infty} \\frac{1}{n} = 0 $$
+";
+
+const TABLE_STORM: &str = "\
+| h1 | h2 | h3 | h4 |
+| -- | -- | -- | -- |
+| a  | b  | c  | d  |
+| e  | f  | g  | h  |
+| i  | j  | k  | l  |
+| m  | n  | o  | p  |
+| q  | r  | s  | t  |
+| u  | v  | w  | x  |
+| y  | z  | 1  | 2  |
+| 3  | 4  | 5  | 6  |
+| 7  | 8  | 9  | 0  |
+";
+
+fn concat_links_md(n: usize) -> String {
+    let mut s = String::from("# Link storm\n\n");
+    for i in 0..n {
+        s.push_str(&format!("[link {0}](https://example.com/p{0}), ", i));
+    }
+    s.push('\n');
+    s
+}
+
+fn repeat_blocks_md(block: &str, n: usize) -> String {
+    let mut s = String::new();
+    for _ in 0..n {
+        s.push_str(block);
+    }
+    s
+}
+
+fn big_doc(pages_target: usize) -> String {
+    let para = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, \
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo \
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse \
+                cillum dolore eu fugiat nulla pariatur.";
+    let mut s = String::new();
+    for _ in 0..(pages_target * 8) {
+        s.push_str(para);
+        s.push_str("\n\n");
+    }
+    s
+}
+
+#[derive(Default)]
+struct CategoryTally {
+    count: usize,
+    raw_bytes: usize,
+    dict_bytes: usize,
+}
+
+impl CategoryTally {
+    fn record(&mut self, raw: usize, dict: usize) {
+        self.count += 1;
+        self.raw_bytes += raw;
+        self.dict_bytes += dict;
+    }
+}
+
+fn category(obj: &Object) -> String {
+    match obj {
+        Object::Stream(s) => name_pair(&s.dict, "stream"),
+        Object::Dictionary(d) => name_pair(d, "dict"),
+        _ => "other".into(),
+    }
+}
+
+fn name_pair(d: &lopdf::Dictionary, kind: &str) -> String {
+    let ty = d.get(b"Type").ok().and_then(|o| o.as_name().ok())
+        .map(|n| String::from_utf8_lossy(n).into_owned());
+    let sub = d.get(b"Subtype").ok().and_then(|o| o.as_name().ok())
+        .map(|n| String::from_utf8_lossy(n).into_owned());
+    match (ty.as_deref(), sub.as_deref()) {
+        (Some(t), Some(s)) => format!("{kind}:/{t}//{s}"),
+        (Some(t), None) => format!("{kind}:/{t}"),
+        (None, Some(s)) => format!("{kind}:?/{s}"),
+        (None, None) if kind == "stream" => "stream:content".into(),
+        (None, None) => format!("{kind}:?"),
+    }
+}
+
+fn approx_obj_bytes(obj: &Object) -> usize {
+    match obj {
+        Object::String(s, _) => s.len() + 2,
+        Object::Name(n) => n.len() + 1,
+        Object::Integer(n) => n.to_string().len(),
+        Object::Real(f) => format!("{:.4}", f).len(),
+        Object::Boolean(_) => 5,
+        Object::Reference(_) => 8,
+        Object::Null => 4,
+        Object::Array(items) => items.iter().map(approx_obj_bytes).sum::<usize>() + 2,
+        Object::Dictionary(d) => {
+            d.iter().map(|(k, v)| k.len() + 2 + approx_obj_bytes(v)).sum::<usize>() + 4
+        }
+        Object::Stream(_) => 0,
+    }
+}
+
+fn approx_dict_bytes(obj: &Object) -> usize {
+    match obj {
+        Object::Stream(s) => {
+            s.dict.iter().fold(0, |a, (k, v)| a + k.len() + 2 + approx_obj_bytes(v))
+        }
+        Object::Dictionary(d) => {
+            d.iter().fold(0, |a, (k, v)| a + k.len() + 2 + approx_obj_bytes(v))
+        }
+        _ => approx_obj_bytes(obj),
+    }
+}
+
+/// Re-serialize without object/xref streams, no Flate, so we can
+/// see the raw operator soup. Returns (uncompressed_size,
+/// gzip_only_size).
+fn uncompressed_size(doc_bytes: &[u8]) -> Option<usize> {
+    let mut doc = Document::load_mem(doc_bytes).ok()?;
+    // Decompress every stream that has a filter so .content holds
+    // the post-filter bytes; saving with `compress: false` then
+    // writes them raw.
+    doc.decompress();
+    let mut out = Vec::new();
+    let _ = doc.save_with_options(&mut out, SaveOptions {
+        use_object_streams: false,
+        use_xref_streams: false,
+        ..Default::default()
+    });
+    Some(out.len())
+}
+
+fn audit(label: &str, bytes: &[u8]) {
+    let total = bytes.len();
+    let Ok(doc) = Document::load_mem(bytes) else {
+        println!("UNREADABLE {label} ({total} B)");
+        return;
+    };
+    let page_count = doc.page_iter().count();
+    let mut tally: BTreeMap<String, CategoryTally> = BTreeMap::new();
+    let mut total_payload = 0usize;
+    let mut form_xobject_ids: Vec<lopdf::ObjectId> = Vec::new();
+    let mut content_stream_lens: Vec<usize> = Vec::new();
+    let mut font_ref_counter: HashMap<lopdf::ObjectId, usize> = HashMap::new();
+
+    for (id, obj) in doc.objects.iter() {
+        let cat = category(obj);
+        let raw = if let Object::Stream(s) = obj { s.content.len() } else { 0 };
+        total_payload += raw;
+        let dict = approx_dict_bytes(obj);
+        tally.entry(cat).or_default().record(raw, dict);
+        if let Object::Stream(s) = obj {
+            let subtype = s.dict.get(b"Subtype").ok().and_then(|o| o.as_name().ok());
+            if subtype == Some(&b"Form"[..]) {
+                form_xobject_ids.push(*id);
+            }
+            // Content streams have no /Type and no /Subtype; they
+            // appear as `stream:content` in the tally.
+            if s.dict.get(b"Type").is_err() && s.dict.get(b"Subtype").is_err() {
+                content_stream_lens.push(s.content.len());
+            }
+        }
+    }
+
+    // Count how often each /Font object is referenced from any
+    // page's /Resources/Font dict; tells us whether fonts are
+    // shared via the page tree or duplicated per page.
+    for pid in doc.page_iter() {
+        if let Ok(font_dict) = doc.get_object(pid).and_then(|p| {
+            p.as_dict().and_then(|d| d.get(b"Resources"))
+        }).and_then(|r| match r {
+            Object::Reference(rid) => doc.get_object(*rid).and_then(|o| o.as_dict()),
+            other => other.as_dict(),
+        }).and_then(|res| res.get(b"Font").and_then(|f| match f {
+            Object::Reference(rid) => doc.get_object(*rid).and_then(|o| o.as_dict()),
+            other => other.as_dict(),
+        })) {
+            for (_, v) in font_dict.iter() {
+                if let Object::Reference(rid) = v {
+                    *font_ref_counter.entry(*rid).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    // Pre-compression / structural-overhead estimate.
+    let uncompressed = uncompressed_size(bytes).unwrap_or(0);
+
+    println!("=== {label}");
+    println!(
+        "    file_size={total} B  pages={page_count}  objects={}  payload_decoded={total_payload} B (~{:.1}x file)  uncompressed_form={} B (~{:.1}x file)",
+        doc.objects.len(),
+        total_payload as f64 / total.max(1) as f64,
+        uncompressed,
+        uncompressed as f64 / total.max(1) as f64,
+    );
+    println!(
+        "    forms={}  content_streams={}  font_refs_by_page={:?}",
+        form_xobject_ids.len(),
+        content_stream_lens.len(),
+        font_ref_counter.values().collect::<Vec<_>>(),
+    );
+
+    let mut rows: Vec<(&String, &CategoryTally)> = tally.iter().collect();
+    rows.sort_by(|a, b| {
+        (b.1.raw_bytes + b.1.dict_bytes).cmp(&(a.1.raw_bytes + a.1.dict_bytes))
+    });
+    for (cat, t) in rows.iter().take(10) {
+        if t.raw_bytes + t.dict_bytes < 50 {
+            continue;
+        }
+        let avg = if t.count > 0 {
+            (t.raw_bytes + t.dict_bytes) / t.count
+        } else {
+            0
+        };
+        println!(
+            "    {:<28} n={:<4} payload={:<7} dict~{:<7} avg/obj={}",
+            cat, t.count, t.raw_bytes, t.dict_bytes, avg,
+        );
+    }
+    println!();
+}
+
+/// Inflate a Flate-encoded stream payload via lopdf's built-in
+/// `decompressed_content`. Returns the original bytes when there
+/// is no filter or decoding fails.
+fn inflate_stream(s: &lopdf::Stream) -> Vec<u8> {
+    let mut copy = s.clone();
+    let _ = copy.decompress();
+    copy.content
+}
+
+/// Pretty-print decompressed bytes; replace newlines with ↵ and
+/// truncate to `limit`.
+fn snippet(bytes: &[u8], limit: usize) -> String {
+    let s = String::from_utf8_lossy(bytes);
+    let truncated: String = s.chars().take(limit).collect();
+    truncated.replace('\n', "↵")
+}
+
+fn dump_math_forms(label: &str, bytes: &[u8], limit: usize) {
+    let Ok(doc) = Document::load_mem(bytes) else { return };
+    println!("--- {label}: first {limit} Form XObject streams (inflated) ---");
+    let mut shown = 0usize;
+    let mut decompressed_total = 0usize;
+    for (_, obj) in doc.objects.iter() {
+        if shown >= limit {
+            break;
+        }
+        let Object::Stream(s) = obj else { continue };
+        let subtype = s.dict.get(b"Subtype").ok().and_then(|o| o.as_name().ok());
+        if subtype != Some(&b"Form"[..]) {
+            continue;
+        }
+        let dict_keys: Vec<String> = s.dict.iter()
+            .map(|(k, _)| String::from_utf8_lossy(k).into_owned())
+            .collect();
+        let inflated = inflate_stream(s);
+        decompressed_total += inflated.len();
+        let matrix = s.dict.get(b"Matrix").ok().map(|o| format!("{o:?}"));
+        let bbox = s.dict.get(b"BBox").ok().map(|o| format!("{o:?}"));
+        println!(
+            "    keys={:?}  matrix={}  bbox={}",
+            dict_keys,
+            matrix.unwrap_or_else(|| "?".into()),
+            bbox.unwrap_or_else(|| "?".into()),
+        );
+        println!(
+            "      compressed={} B  inflated={} B  ratio={:.1}x",
+            s.content.len(), inflated.len(),
+            inflated.len() as f64 / s.content.len().max(1) as f64,
+        );
+        println!("      ops: {}", snippet(&inflated, 240));
+        shown += 1;
+    }
+    if shown > 0 {
+        println!("    (decompressed total for {} forms: {} B)", shown, decompressed_total);
+    }
+    println!();
+}
+
+fn dump_first_page_content(label: &str, bytes: &[u8], take: usize) {
+    let Ok(doc) = Document::load_mem(bytes) else { return };
+    println!("--- {label}: page content stream (inflated) ---");
+    for (_, obj) in doc.objects.iter() {
+        let Object::Stream(s) = obj else { continue };
+        if s.dict.get(b"Type").is_ok() || s.dict.get(b"Subtype").is_ok() {
+            continue;
+        }
+        let inflated = inflate_stream(s);
+        println!(
+            "    compressed={} B  inflated={} B  ratio={:.1}x",
+            s.content.len(), inflated.len(),
+            inflated.len() as f64 / s.content.len().max(1) as f64,
+        );
+        println!("    ops: {}", snippet(&inflated, take));
+        break;
+    }
+    println!();
+}
+
+/// Quick scan of a content stream for tell-tale inefficiencies:
+/// float precision (digits after decimal), BT/ET pair density,
+/// repeated graphics state push/pop.
+fn op_pattern_stats(bytes: &[u8]) -> String {
+    let s = String::from_utf8_lossy(bytes);
+    let bt = s.matches(" BT").count() + s.matches("\nBT").count();
+    let et = s.matches(" ET").count() + s.matches("\nET").count();
+    let q = s.matches(" q\n").count() + s.matches("\nq\n").count();
+    let qq = s.matches(" Q\n").count() + s.matches("\nQ\n").count();
+    let tf = s.matches(" Tf").count();
+    let cm = s.matches(" cm").count();
+    let mut decimals = [0usize; 10];
+    let mut in_frac = false;
+    let mut frac_digits = 0usize;
+    for c in s.chars() {
+        if c == '.' {
+            in_frac = true;
+            frac_digits = 0;
+        } else if in_frac && c.is_ascii_digit() {
+            frac_digits += 1;
+        } else if in_frac {
+            decimals[frac_digits.min(9)] += 1;
+            in_frac = false;
+        }
+    }
+    format!(
+        "BT/ET={bt}/{et}  q/Q={q}/{qq}  Tf={tf}  cm={cm}  frac_digit_distribution={:?}",
+        &decimals[1..],
+    )
+}
+
+#[test]
+#[ignore]
+fn audit_probe_renders() {
+    let mut renders: Vec<(String, Vec<u8>)> = Vec::new();
+    for (label, md) in probes() {
+        match parse_into_bytes(md.to_string(), ConfigSource::Default, None) {
+            Ok(b) => renders.push((label.to_string(), b)),
+            Err(e) => println!("RENDER FAIL {label}: {e}"),
+        }
+    }
+    for (label, bytes) in &renders {
+        audit(label, bytes);
+    }
+    // Drill into the worst math offender + the admonition icons +
+    // a multi-page doc for cross-page resource sharing.
+    if let Some((label, b)) = renders.iter().find(|(l, _)| l == "math_display") {
+        dump_math_forms(label, b, 3);
+    }
+    if let Some((label, b)) = renders.iter().find(|(l, _)| l == "math_repeated_glyph") {
+        dump_math_forms(label, b, 4);
+    }
+    if let Some((label, b)) = renders.iter().find(|(l, _)| l == "admonitions_all") {
+        dump_first_page_content(label, b, 800);
+    }
+    if let Some((label, b)) = renders.iter().find(|(l, _)| l == "page_storm_10") {
+        dump_first_page_content(label, b, 600);
+    }
+    if let Some((label, b)) = renders.iter().find(|(l, _)| l == "math_same_eq_twice") {
+        dump_math_forms(label, b, 0);
+        // Just print form count from the audit above; the dump
+        // limit=0 still prints the header so the reader can see
+        // we looked.
+        if let Ok(doc) = Document::load_mem(b) {
+            let forms = doc.objects.values().filter(|o| {
+                if let Object::Stream(s) = o {
+                    s.dict.get(b"Subtype").ok().and_then(|x| x.as_name().ok())
+                        == Some(&b"Form"[..])
+                } else {
+                    false
+                }
+            }).count();
+            println!("  {label}: form count = {forms} (single equation = 5 forms)");
+        }
+    }
+    if let Some((label, b)) = renders.iter().find(|(l, _)| l == "math_same_eq_x10") {
+        if let Ok(doc) = Document::load_mem(b) {
+            let forms = doc.objects.values().filter(|o| {
+                if let Object::Stream(s) = o {
+                    s.dict.get(b"Subtype").ok().and_then(|x| x.as_name().ok())
+                        == Some(&b"Form"[..])
+                } else {
+                    false
+                }
+            }).count();
+            println!("  {label}: form count = {forms} (single equation = 5 forms; \
+                      with cross-eq dedup expected ~5, without ~50)");
+        }
+    }
+    // Operator-pattern stats on the worst content-stream cases.
+    for label in ["paragraphs+table", "table_storm", "hr_storm",
+                  "admonitions_x10", "page_storm_50"] {
+        if let Some((_, b)) = renders.iter().find(|(l, _)| l == label) {
+            if let Ok(doc) = Document::load_mem(b) {
+                for (_, obj) in doc.objects.iter() {
+                    let Object::Stream(s) = obj else { continue };
+                    if s.dict.get(b"Type").is_ok() || s.dict.get(b"Subtype").is_ok() {
+                        continue;
+                    }
+                    let inflated = inflate_stream(s);
+                    println!("  ops[{label}]: {} (inflated={} B)",
+                             op_pattern_stats(&inflated), inflated.len());
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/tests/render/config_fidelity.rs
+++ b/tests/render/config_fidelity.rs
@@ -1,0 +1,981 @@
+//! Hardcore coverage for the `bugfix/config-style-fidelity` branch
+//! fixes. Each behavioral change gets at least one happy-path test, a
+//! "did the no-op stay a no-op?" test, and (where relevant) a negative
+//! test that pins down deliberately-not-inherited behavior.
+//!
+//! All tests live behind the public `parse_into_bytes` API. Two
+//! helpers make the byte-level assertions reliable:
+//! - `normalize_pdf` strips the few non-deterministic bits the PDF
+//!   writer injects (`/ID`, `/CreationDate`, `/ModDate`, random font
+//!   subset prefixes / object names) so two valid identical renders
+//!   compare equal even though their raw bytes wouldn't.
+//! - `rg_op` formats an RGB triple the way printpdf does (the
+//!   shortest-roundtrip Display form for an `f32`), so a search for a
+//!   given fill-color op matches what's actually in the stream.
+
+use super::common::*;
+use markdown2pdf::config::ConfigSource;
+use markdown2pdf::fonts::FontConfig;
+use markdown2pdf::parse_into_bytes;
+
+/// `Courier New` is the macOS / Windows family that ships as separate
+/// per-weight `.ttf` files, so the sibling-discovery path can locate
+/// bold + italic faces. Linux CI typically lacks it — returning `None`
+/// lets individual tests skip cleanly rather than spuriously fail.
+fn external_mono_family() -> Option<&'static str> {
+    if markdown2pdf::fonts::find_system_font("Courier New").is_some() {
+        Some("Courier New")
+    } else {
+        None
+    }
+}
+
+/// Strip the bits of a rendered PDF that legitimately vary across
+/// otherwise-identical renders: the `/ID` byte string, `/CreationDate`,
+/// `/ModDate`, font-subset prefixes (printpdf assigns a 32-char
+/// alphabetic ID per embedded subset, distinct per run), and the
+/// random `H...` font names that printpdf hands to its built-in font
+/// dictionaries. Two semantically equivalent renders compare equal
+/// after normalization.
+fn normalize_pdf(bytes: &[u8]) -> Vec<u8> {
+    let mut s = String::from_utf8_lossy(&scan(bytes)).into_owned();
+    // /ID[(...)(...)]
+    s = strip_between(&s, "/ID[", "]");
+    s = strip_after_marker(&s, "/CreationDate(", ')');
+    s = strip_after_marker(&s, "/ModDate(", ')');
+    // printpdf's 32-char A–J subset prefixes used as font names.
+    // Replace any run of `[A-J]{32}` (their charset) with a fixed
+    // token so two renders that picked different prefixes still
+    // compare equal.
+    let bytes = s.into_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 32 <= bytes.len()
+            && bytes[i..i + 32]
+                .iter()
+                .all(|b| (b'A'..=b'J').contains(b))
+        {
+            out.extend_from_slice(b"<FONTID>");
+            i += 32;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+fn strip_between(s: &str, open: &str, close: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(start) = rest.find(open) {
+        out.push_str(&rest[..start]);
+        out.push_str(open);
+        out.push_str("<NORMALIZED>");
+        rest = &rest[start + open.len()..];
+        if let Some(end) = rest.find(close) {
+            out.push_str(&rest[end..end + close.len()]);
+            rest = &rest[end + close.len()..];
+        } else {
+            break;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn strip_after_marker(s: &str, marker: &str, end_char: char) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(start) = rest.find(marker) {
+        out.push_str(&rest[..start]);
+        out.push_str(marker);
+        out.push_str("<NORMALIZED>");
+        rest = &rest[start + marker.len()..];
+        if let Some(end) = rest.find(end_char) {
+            rest = &rest[end..];
+            if let Some(c) = rest.chars().next() {
+                out.push(c);
+                rest = &rest[c.len_utf8()..];
+            }
+        } else {
+            break;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// printpdf serializes SetFillColor as `R G B rg` with each channel
+/// in shortest-roundtrip Display form (`{}` on `f32`). Match that.
+fn rg_op(r: u8, g: u8, b: u8) -> String {
+    format!(
+        "{} {} {} rg",
+        r as f32 / 255.0,
+        g as f32 / 255.0,
+        b as f32 / 255.0
+    )
+}
+
+#[test]
+fn code_block_bold_loads_bold_mono_face_when_external_code_font_present() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    let md = "```\nfn main() {}\n```";
+    let regular = parse_into_bytes(
+        md.to_string(),
+        ConfigSource::Embedded(""),
+        Some(&FontConfig::new().with_code_font(mono)),
+    )
+    .expect("render regular");
+    let bold = parse_into_bytes(
+        md.to_string(),
+        ConfigSource::Embedded("[code_block]\nfont_weight = \"bold\""),
+        Some(&FontConfig::new().with_code_font(mono)),
+    )
+    .expect("render bold");
+    // The bold face is a separate font subset, so the bold PDF must
+    // embed strictly more font bytes than the regular one. A meaningful
+    // margin (>=1 KB) rules out timestamp / ID noise. The pre-fix
+    // renderer flagged only `mono_regular` in VariantUsage so
+    // external_code never loaded its bold sibling, and the sizes
+    // matched.
+    assert!(
+        bold.len() > regular.len() + 1024,
+        "bold code block did not embed a bold mono face \
+         (regular {} bytes, bold {} bytes — expected a >=1 KB margin)",
+        regular.len(),
+        bold.len()
+    );
+}
+
+#[test]
+fn code_block_italic_loads_italic_mono_face_when_external_code_font_present() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    // Long enough block that a second-face glyph subset is big
+    // enough to clearly exceed any timestamp / ID noise margin.
+    let md = "```\n\
+fn main() { let abcdefghijklmnopqrstuvwxyz = 0; }\n\
+let extra_text_for_a_bigger_subset_table = true;\n\
+```";
+    let regular = parse_into_bytes(
+        md.to_string(),
+        ConfigSource::Embedded(""),
+        Some(&FontConfig::new().with_code_font(mono)),
+    )
+    .expect("render regular");
+    let italic = parse_into_bytes(
+        md.to_string(),
+        ConfigSource::Embedded("[code_block]\nfont_style = \"italic\""),
+        Some(&FontConfig::new().with_code_font(mono)),
+    )
+    .expect("render italic");
+    assert!(
+        italic.len() > regular.len() + 1024,
+        "italic code block did not embed an italic mono face \
+         (regular {} bytes, italic {} bytes)",
+        regular.len(),
+        italic.len()
+    );
+}
+
+#[test]
+fn code_block_no_weight_override_is_normalize_identical() {
+    // The variant-usage augmentation reads [code_block]'s weight; with
+    // nothing set, it must not perturb the baseline render even though
+    // the augmentation runs unconditionally.
+    let a = render("```\nx\n```", "");
+    let b = render("```\nx\n```", "");
+    assert_eq!(
+        normalize_pdf(&a),
+        normalize_pdf(&b),
+        "two identical renders diverged after metadata normalization"
+    );
+}
+
+#[test]
+fn code_block_bold_with_builtin_courier_uses_courier_bold_handle() {
+    // Without an external code font, [code_block].font_weight=bold
+    // must still route through builtin CourierBold; pre-existing
+    // behavior, regression-guarded here.
+    let bytes = render("```\nx\n```", "[code_block]\nfont_weight = \"bold\"");
+    let has_bold_courier = contains_text(&bytes, "Courier-Bold")
+        || contains_text(&bytes, "CourierBold");
+    assert!(
+        has_bold_courier,
+        "bold code block did not pick a builtin Courier-Bold variant"
+    );
+}
+
+#[test]
+fn list_inside_blockquote_inherits_blockquote_text_color() {
+    let md = "> Quote line.\n>\n> - first item\n> - second item\n";
+    let cfg = r##"
+        [blockquote]
+        text_color = "#1A6ED8"
+    "##;
+    let bytes = render(md, cfg);
+    let needle = rg_op(0x1A, 0x6E, 0xD8);
+    let count = count_substr(&scan(&bytes), needle.as_bytes());
+    // Body paragraph + bullet + item text for each of 2 items.
+    // Conservatively assert >= 3 (paragraph + 2 item baselines).
+    assert!(
+        count >= 3,
+        "expected the blockquote text color {:?} on the body paragraph \
+         AND the nested list (>= 3 fills); got {}",
+        needle,
+        count
+    );
+}
+
+#[test]
+fn ordered_list_inside_blockquote_inherits_text_color() {
+    let md = "> A quote.\n>\n> 1. one\n> 2. two\n";
+    let cfg = r##"
+        [blockquote]
+        text_color = "#22AA66"
+    "##;
+    let bytes = render(md, cfg);
+    let needle = rg_op(0x22, 0xAA, 0x66);
+    assert!(
+        count_substr(&scan(&bytes), needle.as_bytes()) >= 3,
+        "ordered list inside blockquote did not inherit the container color"
+    );
+}
+
+#[test]
+fn list_inside_admonition_inherits_text_color() {
+    let md = "!!! note\n    Body sentence.\n\n    - alpha\n    - beta\n";
+    let cfg = r##"
+        [admonition.note]
+        text_color = "#AA3300"
+    "##;
+    let bytes = render(md, cfg);
+    let needle = rg_op(0xAA, 0x33, 0x00);
+    assert!(
+        count_substr(&scan(&bytes), needle.as_bytes()) >= 3,
+        "list inside admonition did not inherit the container color"
+    );
+}
+
+#[test]
+fn code_block_inside_blockquote_keeps_its_own_text_color() {
+    let md = "> quoted body\n>\n> ```\n> x = 1\n> ```\n";
+    let cfg = r##"
+        [blockquote]
+        text_color = "#FF0000"
+
+        [code_block]
+        text_color = "#00AA00"
+    "##;
+    let bytes = render(md, cfg);
+    let scanned = scan(&bytes);
+    let bq = rg_op(0xFF, 0x00, 0x00);
+    let cb = rg_op(0x00, 0xAA, 0x00);
+    assert!(
+        count_substr(&scanned, bq.as_bytes()) >= 1,
+        "blockquote body should still paint its own color {:?}",
+        bq
+    );
+    assert!(
+        count_substr(&scanned, cb.as_bytes()) >= 1,
+        "code block inside blockquote must keep its own configured \
+         color {:?} (inheritance is for lists only, by design)",
+        cb
+    );
+}
+
+#[test]
+fn top_level_list_default_render_is_normalize_identical_across_runs() {
+    let md = "- one\n- two\n- three\n";
+    let a = render(md, "");
+    let b = render(md, "");
+    assert_eq!(
+        normalize_pdf(&a),
+        normalize_pdf(&b),
+        "deterministic re-render of a plain list diverged"
+    );
+}
+
+#[test]
+fn nested_list_inside_blockquote_inherits_too() {
+    // List-inside-list-inside-blockquote: the inherit path runs for
+    // every nesting level because text_style_override is still set
+    // across the recursive render_block call.
+    let md = "\
+> Quote.\n\
+>\n\
+> - outer\n\
+>   - inner\n\
+>   - inner two\n\
+> - outer two\n";
+    let cfg = r##"
+        [blockquote]
+        text_color = "#3344CC"
+    "##;
+    let bytes = render(md, cfg);
+    let needle = rg_op(0x33, 0x44, 0xCC);
+    // Body paragraph + 4 list item lines minimum (each item paints
+    // the inherited color at least once).
+    let count = count_substr(&scan(&bytes), needle.as_bytes());
+    assert!(
+        count >= 5,
+        "nested list inside blockquote: only {} inherited-color fills found",
+        count
+    );
+}
+
+#[test]
+fn task_list_inside_blockquote_inherits_text_color() {
+    let md = "> Quote.\n>\n> - [ ] todo\n> - [x] done\n";
+    let cfg = r##"
+        [blockquote]
+        text_color = "#5566AA"
+    "##;
+    let bytes = render(md, cfg);
+    let needle = rg_op(0x55, 0x66, 0xAA);
+    // Body + 2 task labels = >= 3.
+    assert!(
+        count_substr(&scan(&bytes), needle.as_bytes()) >= 3,
+        "task list inside blockquote did not inherit the container color"
+    );
+}
+
+#[test]
+fn code_inline_font_family_equal_to_code_block_is_a_no_op() {
+    // Default theme spells both as "Courier"; with no override this
+    // must stay identical (modulo PDF metadata) to a render with both
+    // fields explicitly set to "Courier" (no second font loaded).
+    let a = render("plain `code` line", "");
+    let b = render(
+        "plain `code` line",
+        r##"
+        [code_block]
+        font_family = "Courier"
+        [code_inline]
+        font_family = "Courier"
+    "##,
+    );
+    assert_eq!(
+        normalize_pdf(&a),
+        normalize_pdf(&b),
+        "matching font_family on both [code_block] and [code_inline] \
+         should be a no-op vs the default-theme baseline"
+    );
+}
+
+#[test]
+fn code_inline_font_family_distinct_from_code_block_loads_a_second_family() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    let baseline = render("plain `code` line\n\n```\nblock\n```\n", "");
+    let with_inline_font = render(
+        "plain `code` line\n\n```\nblock\n```\n",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    assert!(
+        with_inline_font.len() > baseline.len() + 4 * 1024,
+        "distinct code_inline.font_family did not embed a second font \
+         (baseline {} vs override {} — expected >=4 KB growth)",
+        baseline.len(),
+        with_inline_font.len()
+    );
+}
+
+#[test]
+fn code_inline_font_family_routes_through_a_distinct_font_handle() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    // With an external code font for code blocks AND a different
+    // [code_inline].font_family, the page content stream must
+    // reference >= 2 distinct external font handles: one for the
+    // inline `code` span, a different one for the fenced block.
+    // Before the fix, both inline and block used the single
+    // external_code family.
+    let Some(other) = any_system_font() else {
+        eprintln!("skip: no second system font available");
+        return;
+    };
+    // Different external families for code-block (via --code-font)
+    // and inline-code (via [code_inline].font_family). They can't
+    // collapse onto the same handle.
+    let bytes = parse_into_bytes(
+        "plain `code` here\n\n```\nblock body\n```\n".to_string(),
+        ConfigSource::Embedded(&format!(
+            "[code_inline]\nfont_family = \"{other}\""
+        )),
+        Some(&FontConfig::new().with_code_font(mono)),
+    )
+    .expect("render");
+    let scanned = scan(&bytes);
+    let s = String::from_utf8_lossy(&scanned);
+    let mut handles = std::collections::HashSet::new();
+    for line in s.lines() {
+        let line = line.trim();
+        if let Some(stripped) = line.strip_prefix('/') {
+            if line.ends_with(" Tf") {
+                let name: String = stripped
+                    .chars()
+                    .take_while(|c| !c.is_whitespace())
+                    .collect();
+                if name.len() == 32
+                    && name.chars().all(|c| ('A'..='J').contains(&c))
+                {
+                    handles.insert(name);
+                }
+            }
+        }
+    }
+    assert!(
+        handles.len() >= 2,
+        "expected >= 2 distinct external font handles (code-block \
+         + inline-code); got {} ({:?})",
+        handles.len(),
+        handles
+    );
+}
+
+#[test]
+fn kbd_html_inline_routes_through_code_inline_font_family() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    // `<kbd>` is lowered with `with_inline_code()`, so it picks up
+    // `[code_inline].font_family` exactly like a backticked span.
+    let baseline = render("Press <kbd>Enter</kbd>.", "");
+    let routed = render(
+        "Press <kbd>Enter</kbd>.",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    assert!(
+        routed.len() > baseline.len() + 4 * 1024,
+        "<kbd> did not pick up the distinct code_inline.font_family"
+    );
+}
+
+#[test]
+fn code_inline_font_family_unset_does_not_load_a_third_family() {
+    // With nothing configured the inline-code family must stay empty.
+    // Two identical renders should differ only in PDF metadata.
+    let a = render("`x`", "");
+    let b = render("`x`", "");
+    assert_eq!(
+        normalize_pdf(&a),
+        normalize_pdf(&b),
+        "two identical renders diverged after metadata normalization"
+    );
+}
+
+#[test]
+fn bold_inline_code_picks_a_bold_face_when_distinct_family_is_configured() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    let regular = render(
+        "Lead `code` trail.",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    let bold = render(
+        "Lead **`code`** trail.",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    // Bold inline-code embeds a second face of the inline-code family.
+    assert!(
+        bold.len() > regular.len() + 1024,
+        "bold inline code did not embed a bold face of the inline-code family \
+         (regular {} bytes, bold {} bytes)",
+        regular.len(),
+        bold.len()
+    );
+}
+
+#[test]
+fn code_inline_padding_unset_is_normalize_identical_to_baseline() {
+    // The wrap-pipeline change always runs; with padding=0 it must
+    // be a strict no-op (no TJ offset emitted, no width change).
+    let a = render("Lead `code` trail.", "");
+    let b = render("Lead `code` trail.", "");
+    assert_eq!(
+        normalize_pdf(&a),
+        normalize_pdf(&b),
+        "two identical renders diverged after metadata normalization"
+    );
+}
+
+#[test]
+fn code_inline_horizontal_padding_emits_two_tj_offsets_per_span() {
+    // Padding emits as `[-N.NNNN] TJ` (PDF's text-position-adjust)
+    // — one before the inline-code text, one after.
+    let baseline = render("Lead `code` trail.", "");
+    let padded = render(
+        "Lead `code` trail.",
+        r##"
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    let baseline_tj = count_substr(&scan(&baseline), b" TJ");
+    let padded_tj = count_substr(&scan(&padded), b" TJ");
+    assert_eq!(
+        padded_tj.checked_sub(baseline_tj).unwrap_or(0),
+        2,
+        "expected exactly 2 boundary TJ offsets for one inline-code \
+         span; baseline TJ {}, padded TJ {}",
+        baseline_tj,
+        padded_tj
+    );
+}
+
+#[test]
+fn code_inline_padding_only_at_span_boundaries_not_per_word() {
+    // A multi-word inline-code span like `foo bar baz` must get
+    // ONE pad pair (boundary), not one per word. With 3 words split
+    // on whitespace, a naive per-word pad would emit 6 offsets;
+    // boundary-only emits 2.
+    let baseline = render("Lead `foo bar baz` trail.", "");
+    let padded = render(
+        "Lead `foo bar baz` trail.",
+        r##"
+        [code_inline]
+        padding = 4.0
+    "##,
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(
+        extra, 2,
+        "expected 2 boundary offsets for one multi-word inline-code \
+         span; got {} (per-word would be 6+)",
+        extra
+    );
+}
+
+#[test]
+fn two_separate_inline_code_spans_each_get_their_own_boundary_pair() {
+    let baseline = render("first `aaa` mid `bbb` last", "");
+    let padded = render(
+        "first `aaa` mid `bbb` last",
+        r##"
+        [code_inline]
+        padding = 3.0
+    "##,
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(
+        extra, 4,
+        "expected 4 offsets total (2 spans × 2 boundaries); got {}",
+        extra
+    );
+}
+
+#[test]
+fn code_inline_padding_does_not_leak_into_mark_highlight() {
+    // [mark]'s background isn't padded — only [code_inline]'s is.
+    // A doc with a `==highlight==` and NO inline code must not emit
+    // boundary TJ ops just because code_inline.padding is set.
+    let baseline = render("Lead ==hi== trail.", "");
+    let with_pad = render(
+        "Lead ==hi== trail.",
+        r##"
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    let baseline_tj = count_substr(&scan(&baseline), b" TJ");
+    let pad_tj = count_substr(&scan(&with_pad), b" TJ");
+    assert_eq!(
+        baseline_tj, pad_tj,
+        "code_inline.padding leaked into mark/highlight emission \
+         (baseline TJ {}, padded {})",
+        baseline_tj, pad_tj
+    );
+}
+
+#[test]
+fn code_inline_padding_does_not_emit_tj_inside_a_code_block() {
+    // Inside a fenced code block `in_code_block` is true → the
+    // inline-code-padding guard skips. A code block must not gain
+    // boundary offsets from this setting.
+    let baseline = render("```\nfn f() {}\n```\n", "");
+    let with_pad = render(
+        "```\nfn f() {}\n```\n",
+        r##"
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    let baseline_tj = count_substr(&scan(&baseline), b" TJ");
+    let pad_tj = count_substr(&scan(&with_pad), b" TJ");
+    assert_eq!(
+        baseline_tj, pad_tj,
+        "code_inline.padding leaked into a code block"
+    );
+}
+
+#[test]
+fn code_inline_vertical_padding_grows_background_box_height() {
+    // With a background color set, the inline-code box is painted
+    // via `draw_filled_rect`. The fill polygon's y-coords change when
+    // padding.top/bottom are nonzero; bytes must diverge.
+    let no_v_pad = render(
+        "Lead `x` trail.",
+        r##"
+        [code_inline]
+        background_color = "#FFEE00"
+    "##,
+    );
+    let with_v_pad = render(
+        "Lead `x` trail.",
+        r##"
+        [code_inline]
+        background_color = "#FFEE00"
+        padding = { top = 2.0, right = 0.0, bottom = 2.0, left = 0.0 }
+    "##,
+    );
+    assert_ne!(
+        normalize_pdf(&no_v_pad),
+        normalize_pdf(&with_v_pad),
+        "vertical inline-code padding did not change the rendered box"
+    );
+}
+
+#[test]
+fn code_inline_padding_at_paragraph_start_still_emits_left_offset() {
+    // Edge: inline code at the very start of the paragraph. The
+    // span is still bounded — non-code on its right — so it gets
+    // both boundary offsets.
+    let baseline = render("`code` trail.", "");
+    let padded = render(
+        "`code` trail.",
+        r##"
+        [code_inline]
+        padding = 4.0
+    "##,
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(extra, 2, "expected 2 boundary offsets at-start; got {}", extra);
+}
+
+#[test]
+fn code_inline_padding_at_paragraph_end_still_emits_right_offset() {
+    let baseline = render("Lead `code`", "");
+    let padded = render(
+        "Lead `code`",
+        r##"
+        [code_inline]
+        padding = 4.0
+    "##,
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(extra, 2, "expected 2 boundary offsets at-end; got {}", extra);
+}
+
+#[test]
+fn code_inline_padding_in_justified_paragraph_emits_both_tj_offsets() {
+    // Justified alignment also emits a TJ-ish op via Tw (word
+    // spacing), so the count comparison must rely on the *delta*
+    // between baseline (justify, no padding) and padded (justify +
+    // padding) for the same alignment. The +2 boundary offsets must
+    // still appear cleanly even though the line is justified.
+    let baseline = render(
+        "Some words `code` more words to force justification fill across the line.",
+        "[paragraph]\ntext_align = \"justify\"",
+    );
+    let padded = render(
+        "Some words `code` more words to force justification fill across the line.",
+        r##"
+        [paragraph]
+        text_align = "justify"
+
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(
+        extra, 2,
+        "justified paragraph + padded inline code should still emit \
+         exactly 2 boundary offsets; got {}",
+        extra
+    );
+}
+
+#[test]
+fn code_inline_padding_in_center_aligned_paragraph_works() {
+    // Center alignment uses an absolute Td per line. Padding still
+    // must emit cleanly and not crash the render.
+    let bytes = render(
+        "Lead `code` trail.",
+        r##"
+        [paragraph]
+        text_align = "center"
+
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    assert!(pdf_well_formed(&bytes));
+    let tj_count = count_substr(&scan(&bytes), b" TJ");
+    assert!(
+        tj_count >= 2,
+        "center-aligned padded inline code emitted {} TJ ops; expected >=2",
+        tj_count
+    );
+}
+
+#[test]
+fn inline_code_in_heading_routes_through_code_inline_font_family() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    // Headings also flow through write_wrapped_runs; an inline code
+    // span inside a heading must pick up [code_inline].font_family.
+    let baseline = render("# Heading with `code` in it", "");
+    let routed = render(
+        "# Heading with `code` in it",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    assert!(
+        routed.len() > baseline.len() + 4 * 1024,
+        "inline code in heading didn't pick up code_inline.font_family"
+    );
+}
+
+#[test]
+fn inline_code_in_table_cell_picks_up_padding() {
+    let baseline = render(
+        "| h1 | h2 |\n| -- | -- |\n| a  | `x` |\n",
+        "",
+    );
+    let padded = render(
+        "| h1 | h2 |\n| -- | -- |\n| a  | `x` |\n",
+        r##"
+        [code_inline]
+        padding = 3.0
+    "##,
+    );
+    // Padding effect — at minimum the bytes must differ (the
+    // boundary TJs appear in the cell's content stream).
+    assert!(
+        padded.len() != baseline.len() || padded != baseline,
+        "inline code inside a table cell did not pick up padding"
+    );
+}
+
+#[test]
+fn bold_italic_inline_code_still_routes_through_inline_code_font_family() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    // `***\`code\`***` → bold + italic + monospace + inline_code flags.
+    // The inline-code family must serve it (falling through to its
+    // bold-italic sibling if loaded, else bold/italic/regular).
+    let regular = render(
+        "plain `code` here",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    let bold_italic = render(
+        "plain ***`code`*** here",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    // At minimum: the bold-italic variant load adds bytes (could be
+    // bold-italic face, or italic + bold fallbacks separately).
+    assert!(
+        bold_italic.len() > regular.len() + 512,
+        "bold-italic inline code didn't pick up any additional face \
+         (regular {} bytes, bold-italic {} bytes)",
+        regular.len(),
+        bold_italic.len()
+    );
+}
+
+#[test]
+fn inline_code_inside_blockquote_still_keeps_code_inline_font_family() {
+    let Some(mono) = external_mono_family() else {
+        eprintln!("skip: no external monospace family installed");
+        return;
+    };
+    // Inside a blockquote the body text inherits container style,
+    // but inline-code routing should stay on the inline-code path
+    // (mono + inline_code flags, routed to external_code_inline).
+    let baseline = render("> Quote with `code` inside.\n", "");
+    let routed = render(
+        "> Quote with `code` inside.\n",
+        &format!(
+            r##"
+            [code_inline]
+            font_family = "{mono}"
+        "##
+        ),
+    );
+    assert!(
+        routed.len() > baseline.len() + 4 * 1024,
+        "inline code inside blockquote didn't pick up code_inline.font_family"
+    );
+}
+
+#[test]
+fn code_inline_padding_works_inside_blockquote() {
+    let baseline = render("> Quote with `code` inside.\n", "");
+    let padded = render(
+        "> Quote with `code` inside.\n",
+        r##"
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(
+        extra, 2,
+        "inline code inside blockquote should emit 2 boundary offsets; got {}",
+        extra
+    );
+}
+
+#[test]
+fn empty_inline_code_does_not_panic() {
+    // Edge: backticks around literally nothing. Often elided by the
+    // lexer but worth a panic-free guard.
+    let bytes = render("Lead `` trail.", "[code_inline]\npadding = 5.0");
+    assert!(pdf_well_formed(&bytes));
+}
+
+#[test]
+fn inline_code_padding_with_letter_spacing_does_not_crash() {
+    // letter_spacing emits SetCharacterSpacing; combined with the
+    // TJ offset for padding it's two state changes per span. Just a
+    // smoke test that nothing collides.
+    let bytes = render(
+        "Lead `code` trail.",
+        r##"
+        [paragraph]
+        letter_spacing_pt = 0.4
+
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    assert!(pdf_well_formed(&bytes));
+    let tj = count_substr(&scan(&bytes), b" TJ");
+    assert!(
+        tj >= 2,
+        "expected at least 2 TJ offsets even with letter spacing; got {}",
+        tj
+    );
+}
+
+#[test]
+fn many_consecutive_inline_code_spans_each_get_their_own_boundary_pair() {
+    // Stress: 5 spans → 10 boundary offsets.
+    let baseline = render("a `1` b `2` c `3` d `4` e `5` f", "");
+    let padded = render(
+        "a `1` b `2` c `3` d `4` e `5` f",
+        "[code_inline]\npadding = 3.0",
+    );
+    let extra = count_substr(&scan(&padded), b" TJ")
+        - count_substr(&scan(&baseline), b" TJ");
+    assert_eq!(
+        extra, 10,
+        "expected 10 boundary offsets (5 spans × 2); got {}",
+        extra
+    );
+}
+
+#[test]
+fn nested_list_in_blockquote_color_does_not_paint_outside_callout() {
+    // Negative: text outside the blockquote stays the default text
+    // color, not the blockquote color.
+    let bytes = render(
+        "Plain paragraph here.\n\n> - quoted item one\n> - quoted item two\n\nAnother plain paragraph.\n",
+        r##"
+        [blockquote]
+        text_color = "#1234FF"
+    "##,
+    );
+    let inherit = rg_op(0x12, 0x34, 0xFF);
+    let default_black = rg_op(0, 0, 0);
+    let scanned = scan(&bytes);
+    assert!(
+        count_substr(&scanned, inherit.as_bytes()) >= 2,
+        "blockquote color should fire for both list items"
+    );
+    // Both plain paragraphs paint with the default text color.
+    assert!(
+        count_substr(&scanned, default_black.as_bytes()) >= 2,
+        "plain paragraphs outside the blockquote must NOT inherit"
+    );
+}
+
+#[test]
+fn code_inline_padding_increases_pdf_size_meaningfully() {
+    // Sanity: extra TJ ops + extra spacing data must visibly grow
+    // the content stream. Tiny but >0.
+    let baseline = render("Lead `code` trail.", "");
+    let padded = render(
+        "Lead `code` trail.",
+        r##"
+        [code_inline]
+        padding = 5.0
+    "##,
+    );
+    assert!(
+        padded.len() > baseline.len(),
+        "padded render is not larger than baseline ({} vs {})",
+        padded.len(),
+        baseline.len()
+    );
+}

--- a/tests/render/config_fidelity.rs
+++ b/tests/render/config_fidelity.rs
@@ -1,7 +1,9 @@
-//! Hardcore coverage for the `bugfix/config-style-fidelity` branch
-//! fixes. Each behavioral change gets at least one happy-path test, a
-//! "did the no-op stay a no-op?" test, and (where relevant) a negative
-//! test that pins down deliberately-not-inherited behavior.
+//! Coverage for the class of bug where a config field resolves into
+//! `ResolvedStyle` but the renderer silently ignores it. Each test
+//! pairs a positive assertion ("this field actually moves the output")
+//! with a no-op guard ("with the field unset the render is unchanged")
+//! and, where the behavior is deliberate ("code blocks inside a
+//! blockquote do NOT inherit"), a negative test that pins it down.
 //!
 //! All tests live behind the public `parse_into_bytes` API. Two
 //! helpers make the byte-level assertions reliable:

--- a/tests/render/fonts.rs
+++ b/tests/render/fonts.rs
@@ -219,3 +219,44 @@ fn non_ascii_with_builtin_font_does_not_panic() {
         parse_into_bytes(md, ConfigSource::Default, None).expect("render must not error");
     assert!(bytes.starts_with(b"%PDF-"));
 }
+
+#[test]
+fn unknown_fallback_font_renders_and_degrades_gracefully() {
+    // A configured fallback that can't be located must not error or
+    // panic — it simply doesn't load, and uncovered codepoints stay
+    // uncovered (the pre-fallback behavior).
+    let md = "# Hello 日本語\n\nMixed text.".to_string();
+    let cfg_toml = r#"
+        [defaults]
+        fallback_fonts = ["This_Font_Definitely_Does_Not_Exist_12345"]
+    "#;
+    let bytes = parse_into_bytes(md, ConfigSource::Embedded(cfg_toml), None)
+        .expect("missing fallback must not error");
+    assert!(bytes.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn fallback_font_loads_when_system_font_available() {
+    // When a *real* system font is configured as the fallback, the
+    // renderer must load it and embed it alongside the primary. With
+    // no FontConfig the primary is the built-in Helvetica path, which
+    // emits no `/Ascent` entry — any `/Ascent` value in the PDF must
+    // come from an embedded external font (the fallback).
+    let Some(name) = any_system_font() else {
+        eprintln!("skipping: no system font available");
+        return;
+    };
+    let md = "Body text with Greek Ω and Latin Aé.".to_string();
+    let cfg_toml = format!(
+        "[defaults]\nfallback_fonts = [\"{}\"]\n",
+        name
+    );
+    let bytes = parse_into_bytes(md, ConfigSource::Embedded(&cfg_toml), None)
+        .expect("render must succeed");
+    assert!(bytes.starts_with(b"%PDF-"));
+    let asc = ascents(&bytes);
+    assert!(
+        !asc.is_empty(),
+        "expected at least one embedded font (the fallback) with an `/Ascent` entry, got none"
+    );
+}


### PR DESCRIPTION
**Fallback font chain.** A new `fallback_fonts` list on `[defaults]` in the TOML config (and `FontConfig::with_fallback_fonts(...)` for programmatic callers) takes an ordered list of font names. At render time each codepoint is matched against the primary first, then each fallback in declaration order; the first font that has a real glyph emits it. A codepoint covered by nothing in the chain degrades visibly (a `?` with the built-in primary, a missing-glyph box with an external Unicode primary) rather than failing the render. Names resolve the same way as `font_family`: built-in aliases, system font names, or paths to `.ttf` / `.otf` files; a font that can't be located logs a warning and is skipped. Wrapping and emission stay consistent across font boundaries, so mixed-script paragraphs don't overlap or break early.

**Built-in measurement matches emission.** When no Unicode font is configured, the renderer transliterates non-ASCII punctuation to ASCII before emission (`•` → `*`, `—` → `--`, `…` → `...`, `(c)`, `(R)`, `(TM)`, smart quotes, NBSP). Line measurement, however, priced those source codepoints at the font's average glyph width, so the measured advance disagreed with what was actually drawn. The layout cursor drifted ahead of the PDF text matrix by the difference on every transliterated character, and the error compounded along the line — decorations and link hit-rectangles ended up beside their text rather than under it, most visibly on a line of several links separated by `•` or `—`. Measurement now routes every codepoint through the same transliteration the emit path uses, so the two agree exactly. Documents with no transliterated characters, and any document rendered with a Unicode font, are unaffected.

**Config file discovery.** With no `-c` flag, the CLI now finds a config automatically — `MARKDOWN2PDF_CONFIG`, then `./markdown2pdf.toml`, then `~/.config/markdown2pdf/config.toml` — before the default theme.

**Style-config fidelity.** A class of style fields the renderer was silently dropping is now honoured end-to-end. Body font: system-font lookup returning a bold face (e.g. `Tahoma Bold.ttf`) as the regular weight is fixed (exact filename wins), `[defaults].font_family`
actually loads and embeds, heading bold from the style block is applied with its bold/italic faces embedded, and `[link].underline = false` suppresses the link underline. Per-block: `letter_spacing_pt`, `indent_pt`, `underline` / `strikethrough` / `text_align`, table `cell_padding` and `alternating_row_background`. Inline: every `code_inline` and `[mark]` field including `font_family` and `padding`. Layout: list `indent_per_level_pt` (plus a new `bullet_gap_pt` knob on `[list.common]`, defaulting to the previous `5.67` pt), image caption styling, title-page cover image, admonition body inheritance — nested lists inside a blockquote / admonition now adopt the container's typography. Center- and right-aligned paragraphs no longer collapse their wrapped lines onto line one. Multi-column page layout (`page.columns`) is the only audited field still deferred — [#102](https://github.com/theiskaa/markdown2pdf/issues/102).

Resolves [#81](https://github.com/theiskaa/markdown2pdf/issues/81), [#97](https://github.com/theiskaa/markdown2pdf/issues/97), and [#100](https://github.com/theiskaa/markdown2pdf/issues/100).
